### PR TITLE
Fix warnings, including an inexhaustive match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ env:
   - secure: "BcNzNHmOVQQegY8uI2sOhV5RNpW144M7omUbTIATdxMou690ydk9LJDaWowqyv9JruS6n2ZMu3UO2bf/KySxHG56iZ8mtPtUtp98llWydM37dodGLAK09SX8vD9NqOZ5JK9382Ip83s98DjLrZKdftB4FSt82aOB4erF4hB0ChM="
   matrix:
   - OCAML_VERSION=latest
+  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.01
 branches:
   only: master

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
-2.0.0 (13-Jan-2015):
+2.0.1 (2016-01-14):
+* fix an inexhaustive match exception if the server sends an unexpected
+  response
+
+2.0.0 (13-Jan-2016):
 * New Mirage-style (i.e. Cstruct/Io_page-based) API
 * Support for v2 of the NBD protocol (i.e. multiple disks over the same port)
 * Preliminary support for disk mirroring

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,11 @@ gh-pages:
 
 coverage:
 	bash .coverage.sh
+
+.PHONY: reindent
+reindent:
+	ocp-indent --syntax cstruct -i lib/*.mli
+	ocp-indent --syntax cstruct -i lib/*.ml
+	ocp-indent --syntax cstruct -i lib_test/*.ml
+	ocp-indent --syntax cstruct -i cli/*.ml
+

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name: nbd
-Version: 2.0.0
+Version: 2.0.1
 Synopsis: Pure OCaml implementation of the Network Block Device
 Authors: Jonathan Ludlam, Dave Scott
 License: LGPL-2.1 with OCaml linking exception

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -153,9 +153,6 @@ module Impl = struct
 
   let serve common filename port =
     let filename = require "filename" filename in
-    let stats = Unix.LargeFile.stat filename in
-    let size = stats.Unix.LargeFile.st_size in
-    let flags = [] in
     let t =
       let sock = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
       let sockaddr = Lwt_unix.ADDR_INET(Unix.inet_addr_any, port) in

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -135,7 +135,9 @@ let list channel =
           | `Ok server ->
             loop (server.Server.name :: acc)
           | `Error e -> fail e
-          end in
+          end
+        | `Ok _ ->
+          fail (Failure "Server's OptionResponse had an invalid type") in
       loop []
     end
 

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -45,9 +45,8 @@ module NbdRpc = struct
     | `Error e -> return (`Error e)
     | `Ok () ->
       begin match req_hdr.Request.ty with
-      | Command.Read -> 
+      | Command.Read ->
         (* TODO: use a page-aligned memory allocator *)
-        let expected = Int32.to_int req_hdr.Request.len in
         Lwt_list.iter_s sock.read response_body
         >>= fun () ->
         return (`Ok ())
@@ -61,7 +60,6 @@ module NbdRpc = struct
     match req_body with
     | None -> return ()
     | Some data ->
-      let expected = Cstruct.len data in
       sock.write data
 
   let id_of_request req = req.Request.handle
@@ -180,8 +178,6 @@ let negotiate channel export =
         make channel x.DiskInfo.size x.DiskInfo.flags
         >>= fun t ->
         return (t, x.DiskInfo.size, x.DiskInfo.flags)
-      | `Ok _ ->
-        fail (Failure "Expected to receive size and flags from the server")
       end
     end
 

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -36,31 +36,31 @@ module NbdRpc = struct
   let recv_hdr sock =
     let buf = Cstruct.create 16 in
     lwt () = sock.read buf in
-    match Reply.unmarshal buf with
-    | `Ok x -> return (Some x.Reply.handle, x)
-    | `Error e -> fail e
+  match Reply.unmarshal buf with
+  | `Ok x -> return (Some x.Reply.handle, x)
+  | `Error e -> fail e
 
   let recv_body sock req_hdr res_hdr response_body =
     match res_hdr.Reply.error with
     | `Error e -> return (`Error e)
     | `Ok () ->
       begin match req_hdr.Request.ty with
-      | Command.Read ->
-        (* TODO: use a page-aligned memory allocator *)
-        Lwt_list.iter_s sock.read response_body
-        >>= fun () ->
-        return (`Ok ())
-     | _ -> return (`Ok ())
-     end
+        | Command.Read ->
+          (* TODO: use a page-aligned memory allocator *)
+          Lwt_list.iter_s sock.read response_body
+          >>= fun () ->
+          return (`Ok ())
+        | _ -> return (`Ok ())
+      end
 
   let send_one sock req_hdr req_body =
     let buf = Cstruct.create Request.sizeof in
     Request.marshal buf req_hdr;
     lwt () = sock.write buf in
-    match req_body with
-    | None -> return ()
-    | Some data ->
-      sock.write data
+  match req_body with
+  | None -> return ()
+  | Some data ->
+    sock.write data
 
   let id_of_request req = req.Request.handle
 
@@ -105,40 +105,40 @@ let list channel =
     channel.read buf
     >>= fun () ->
     begin match Negotiate.unmarshal buf kind with
-    | `Error e -> fail e
-    | `Ok (Negotiate.V1 x) ->
-      return (`Error `Unsupported)
-    | `Ok (Negotiate.V2 x) ->
-      let buf = Cstruct.create NegotiateResponse.sizeof in
-      let flags = if List.mem GlobalFlag.Fixed_newstyle x then [ ClientFlag.Fixed_newstyle ] else [] in
-      NegotiateResponse.marshal buf flags;
-      channel.write buf
-      >>= fun () ->
-      let buf = Cstruct.create OptionRequestHeader.sizeof in
-      OptionRequestHeader.(marshal buf { ty = Option.List; length = 0l });
-      channel.write buf
-      >>= fun () ->
-      let buf = Cstruct.create OptionResponseHeader.sizeof in
-      let rec loop acc =
-        channel.read buf
+      | `Error e -> fail e
+      | `Ok (Negotiate.V1 x) ->
+        return (`Error `Unsupported)
+      | `Ok (Negotiate.V2 x) ->
+        let buf = Cstruct.create NegotiateResponse.sizeof in
+        let flags = if List.mem GlobalFlag.Fixed_newstyle x then [ ClientFlag.Fixed_newstyle ] else [] in
+        NegotiateResponse.marshal buf flags;
+        channel.write buf
         >>= fun () ->
-        match OptionResponseHeader.unmarshal buf with
-        | `Error e -> fail e
-        | `Ok { OptionResponseHeader.response_type = OptionResponse.Ack } -> return (`Ok acc)
-        | `Ok { OptionResponseHeader.response_type = OptionResponse.Policy } ->
-          return (`Error `Policy)
-        | `Ok { OptionResponseHeader.response_type = OptionResponse.Server; length } ->
-          let buf' = Cstruct.create (Int32.to_int length) in
-          channel.read buf'
+        let buf = Cstruct.create OptionRequestHeader.sizeof in
+        OptionRequestHeader.(marshal buf { ty = Option.List; length = 0l });
+        channel.write buf
+        >>= fun () ->
+        let buf = Cstruct.create OptionResponseHeader.sizeof in
+        let rec loop acc =
+          channel.read buf
           >>= fun () ->
-          begin match Server.unmarshal buf' with
-          | `Ok server ->
-            loop (server.Server.name :: acc)
+          match OptionResponseHeader.unmarshal buf with
           | `Error e -> fail e
-          end
-        | `Ok _ ->
-          fail (Failure "Server's OptionResponse had an invalid type") in
-      loop []
+          | `Ok { OptionResponseHeader.response_type = OptionResponse.Ack } -> return (`Ok acc)
+          | `Ok { OptionResponseHeader.response_type = OptionResponse.Policy } ->
+            return (`Error `Policy)
+          | `Ok { OptionResponseHeader.response_type = OptionResponse.Server; length } ->
+            let buf' = Cstruct.create (Int32.to_int length) in
+            channel.read buf'
+            >>= fun () ->
+            begin match Server.unmarshal buf' with
+              | `Ok server ->
+                loop (server.Server.name :: acc)
+              | `Error e -> fail e
+            end
+          | `Ok _ ->
+            fail (Failure "Server's OptionResponse had an invalid type") in
+        loop []
     end
 
 let negotiate channel export =
@@ -152,35 +152,35 @@ let negotiate channel export =
     channel.read buf
     >>= fun () ->
     begin match Negotiate.unmarshal buf kind with
-    | `Error e -> fail e
-    | `Ok (Negotiate.V1 x) ->
-      make channel x.Negotiate.size x.Negotiate.flags
-      >>= fun t ->
-      return (t, x.Negotiate.size, x.Negotiate.flags)
-    | `Ok (Negotiate.V2 x) ->
-      let buf = Cstruct.create NegotiateResponse.sizeof in
-      let flags = if List.mem GlobalFlag.Fixed_newstyle x then [ ClientFlag.Fixed_newstyle ] else [] in
-      NegotiateResponse.marshal buf flags;
-      channel.write buf
-      >>= fun () ->
-      let buf = Cstruct.create OptionRequestHeader.sizeof in
-      OptionRequestHeader.(marshal buf { ty = Option.ExportName; length = Int32.of_int (String.length export) });
-      channel.write buf
-      >>= fun () ->
-      let buf = Cstruct.create (ExportName.sizeof export) in
-      ExportName.marshal buf export;
-      channel.write buf
-      >>= fun () ->
-      let buf = Cstruct.create DiskInfo.sizeof in
-      channel.read buf
-      >>= fun () ->
-      begin match DiskInfo.unmarshal buf with
       | `Error e -> fail e
-      | `Ok x ->
-        make channel x.DiskInfo.size x.DiskInfo.flags
+      | `Ok (Negotiate.V1 x) ->
+        make channel x.Negotiate.size x.Negotiate.flags
         >>= fun t ->
-        return (t, x.DiskInfo.size, x.DiskInfo.flags)
-      end
+        return (t, x.Negotiate.size, x.Negotiate.flags)
+      | `Ok (Negotiate.V2 x) ->
+        let buf = Cstruct.create NegotiateResponse.sizeof in
+        let flags = if List.mem GlobalFlag.Fixed_newstyle x then [ ClientFlag.Fixed_newstyle ] else [] in
+        NegotiateResponse.marshal buf flags;
+        channel.write buf
+        >>= fun () ->
+        let buf = Cstruct.create OptionRequestHeader.sizeof in
+        OptionRequestHeader.(marshal buf { ty = Option.ExportName; length = Int32.of_int (String.length export) });
+        channel.write buf
+        >>= fun () ->
+        let buf = Cstruct.create (ExportName.sizeof export) in
+        ExportName.marshal buf export;
+        channel.write buf
+        >>= fun () ->
+        let buf = Cstruct.create DiskInfo.sizeof in
+        channel.read buf
+        >>= fun () ->
+        begin match DiskInfo.unmarshal buf with
+          | `Error e -> fail e
+          | `Ok x ->
+            make channel x.DiskInfo.size x.DiskInfo.flags
+            >>= fun t ->
+            return (t, x.DiskInfo.size, x.DiskInfo.flags)
+        end
     end
 
 type 'a io = 'a Lwt.t
@@ -210,13 +210,13 @@ let write t from buffers =
   then return (`Error `Disconnected)
   else begin
     let rec loop from = function
-    | [] -> return (`Ok ())
-    | b :: bs ->
-      begin write_one t from b
-      >>= function
-      | `Ok () -> loop Int64.(add from (of_int (Cstruct.len b))) bs
-      | `Error e -> return (`Error e)
-      end in
+      | [] -> return (`Ok ())
+      | b :: bs ->
+        begin write_one t from b
+          >>= function
+          | `Ok () -> loop Int64.(add from (of_int (Cstruct.len b))) bs
+          | `Error e -> return (`Error e)
+        end in
     loop from buffers
     >>= function
     | `Ok x -> return (`Ok x)

--- a/lib/mirror.ml
+++ b/lib/mirror.ml
@@ -271,7 +271,6 @@ module Make(Primary: V1_LWT.BLOCK)(Secondary: V1_LWT.BLOCK) = struct
       return (`Ok t)
 
   let read t ofs bufs =
-    let primary_ofs = Int64.(mul ofs (of_int t.primary_block_size)) in
     Primary.read t.primary ofs bufs
 
   let write t ofs bufs =

--- a/lib/mux.ml
+++ b/lib/mux.ml
@@ -46,45 +46,45 @@ module Make = functor (R : RPC) -> struct
   let rec dispatcher t =
     try_lwt
       lwt (id,pkt) = R.recv_hdr t.transport in
-      match id with 
-      | None -> R.handle_unrequested_packet t.transport pkt
-      | Some id -> 
-        if not(Hashtbl.mem t.id_to_wakeup id)
-        then raise_lwt (Unexpected_id id)
-        else begin
-          let request_hdr, waker, response_body = Hashtbl.find t.id_to_wakeup id in
-          R.recv_body t.transport request_hdr pkt response_body
-          >>= fun response -> 
-          Lwt.wakeup waker response;
-          Hashtbl.remove t.id_to_wakeup id;
-          dispatcher t
-        end
-    with e ->
-      t.dispatcher_shutting_down <- true;
-      Hashtbl.iter (fun _ (_,u, _) -> Lwt.wakeup_later_exn u e) t.id_to_wakeup;
-      raise_lwt e
-
-  let rpc req_hdr req_body response_body t = 
-    let sleeper, waker = Lwt.wait () in
-    if t.dispatcher_shutting_down 
-    then raise_lwt Shutdown
+  match id with 
+  | None -> R.handle_unrequested_packet t.transport pkt
+  | Some id -> 
+    if not(Hashtbl.mem t.id_to_wakeup id)
+    then raise_lwt (Unexpected_id id)
     else begin
-      let id = R.id_of_request req_hdr in
-      Hashtbl.add t.id_to_wakeup id (req_hdr, waker, response_body);
-      lwt () = Lwt_mutex.with_lock t.outgoing_mutex
-          (fun () -> R.send_one t.transport req_hdr req_body) in
-      sleeper
+      let request_hdr, waker, response_body = Hashtbl.find t.id_to_wakeup id in
+      R.recv_body t.transport request_hdr pkt response_body
+      >>= fun response -> 
+      Lwt.wakeup waker response;
+      Hashtbl.remove t.id_to_wakeup id;
+      dispatcher t
     end
+with e ->
+t.dispatcher_shutting_down <- true;
+Hashtbl.iter (fun _ (_,u, _) -> Lwt.wakeup_later_exn u e) t.id_to_wakeup;
+raise_lwt e
 
-  let create transport = 
-    let t = {
-      transport = transport;
-      outgoing_mutex = Lwt_mutex.create ();
-      id_to_wakeup = Hashtbl.create 10;
-      dispatcher_thread = Lwt.return ();
-      dispatcher_shutting_down = false; } in
-    t.dispatcher_thread <- dispatcher t;
-    Lwt.return t
+let rpc req_hdr req_body response_body t = 
+  let sleeper, waker = Lwt.wait () in
+  if t.dispatcher_shutting_down 
+  then raise_lwt Shutdown
+  else begin
+    let id = R.id_of_request req_hdr in
+    Hashtbl.add t.id_to_wakeup id (req_hdr, waker, response_body);
+    lwt () = Lwt_mutex.with_lock t.outgoing_mutex
+      (fun () -> R.send_one t.transport req_hdr req_body) in
+sleeper
+end
+
+let create transport = 
+  let t = {
+    transport = transport;
+    outgoing_mutex = Lwt_mutex.create ();
+    id_to_wakeup = Hashtbl.create 10;
+    dispatcher_thread = Lwt.return ();
+    dispatcher_shutting_down = false; } in
+  t.dispatcher_thread <- dispatcher t;
+  Lwt.return t
 
 end
 

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -57,13 +57,13 @@ module PerExportFlag = struct
   let of_int32 x =
     let flags = Int32.to_int x in
     let is_set i mask = i land mask = mask in
-      List.map snd 
-        (List.filter (fun (mask,_) -> is_set flags mask)
-          [ nbd_flag_read_only, Read_only;
-            nbd_flag_send_flush, Send_flush;
-            nbd_flag_send_fua, Send_fua;
-            nbd_flag_rotational, Rotational;
-            nbd_flag_send_trim, Send_trim; ])
+    List.map snd 
+      (List.filter (fun (mask,_) -> is_set flags mask)
+         [ nbd_flag_read_only, Read_only;
+           nbd_flag_send_flush, Send_flush;
+           nbd_flag_send_fua, Send_fua;
+           nbd_flag_rotational, Rotational;
+           nbd_flag_send_trim, Send_trim; ])
 
   let to_int flags =
     let one = function
@@ -87,10 +87,10 @@ module GlobalFlag = struct
 
   let of_int flags =
     let is_set i mask = i land mask = mask in
-      List.map snd 
-        (List.filter (fun (mask,_) -> is_set flags mask)
-          [ nbd_flag_fixed_newstyle, Fixed_newstyle;
-            nbd_flag_no_zeroes, No_zeroes; ])
+    List.map snd 
+      (List.filter (fun (mask,_) -> is_set flags mask)
+         [ nbd_flag_fixed_newstyle, Fixed_newstyle;
+           nbd_flag_no_zeroes, No_zeroes; ])
 
   let to_int flags =
     let one = function
@@ -111,10 +111,10 @@ module ClientFlag = struct
   let of_int32 flags =
     let flags = Int32.to_int flags in
     let is_set i mask = i land mask = mask in
-      List.map snd 
-        (List.filter (fun (mask,_) -> is_set flags mask)
-          [ nbd_flag_c_fixed_newstyle, Fixed_newstyle;
-            nbd_flag_c_no_zeroes, No_zeroes; ])
+    List.map snd 
+      (List.filter (fun (mask,_) -> is_set flags mask)
+         [ nbd_flag_c_fixed_newstyle, Fixed_newstyle;
+           nbd_flag_c_no_zeroes, No_zeroes; ])
 
   let to_int32 flags =
     let one = function
@@ -126,12 +126,12 @@ end
 
 module Error = struct
   type t = [
-  | `EPERM
-  | `EIO
-  | `ENOMEM
-  | `EINVAL
-  | `ENOSPC
-  | `Unknown of int32
+    | `EPERM
+    | `EIO
+    | `ENOMEM
+    | `EINVAL
+    | `ENOSPC
+    | `Unknown of int32
   ] with sexp
 
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
@@ -166,20 +166,20 @@ module Command = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   let of_int32 = function 
-  | 0l -> Read 
-  | 1l -> Write 
-  | 2l -> Disc 
-  | 3l -> Flush 
-  | 4l -> Trim
-  | c  -> Unknown c
+    | 0l -> Read 
+    | 1l -> Write 
+    | 2l -> Disc 
+    | 3l -> Flush 
+    | 4l -> Trim
+    | c  -> Unknown c
 
   let to_int32 = function 
-  | Read -> 0l 
-  | Write -> 1l 
-  | Disc -> 2l 
-  | Flush -> 3l 
-  | Trim -> 4l
-  | Unknown c -> c
+    | Read -> 0l 
+    | Write -> 1l 
+    | Disc -> 2l 
+    | Flush -> 3l 
+    | Trim -> 4l
+    | Unknown c -> c
 
 end
 
@@ -194,16 +194,16 @@ module Option = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   let of_int32 = function
-  | 1l -> ExportName
-  | 2l -> Abort
-  | 3l -> List
-  | c -> Unknown c
+    | 1l -> ExportName
+    | 2l -> Abort
+    | 3l -> List
+    | c -> Unknown c
 
   let to_int32 = function
-  | ExportName -> 1l
-  | Abort -> 2l
-  | List -> 3l
-  | Unknown c -> c
+    | ExportName -> 1l
+    | Abort -> 2l
+    | List -> 3l
+    | Unknown c -> c
 end
 
 module OptionResponse = struct
@@ -220,22 +220,22 @@ module OptionResponse = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   let of_int32 = function
-  | 1l -> Ack
-  | 2l -> Server
-  | -2147483647l -> Unsupported
-  | -2147483646l -> Policy
-  | -2147483645l -> Invalid
-  | -2147483644l -> Platform
-  | x -> Unknown x
+    | 1l -> Ack
+    | 2l -> Server
+    | -2147483647l -> Unsupported
+    | -2147483646l -> Policy
+    | -2147483645l -> Invalid
+    | -2147483644l -> Platform
+    | x -> Unknown x
 
   let to_int32 = function
-  | Ack -> 1l
-  | Server -> 2l
-  | Unsupported -> -2147483647l
-  | Policy -> -2147483646l
-  | Invalid -> -2147483645l
-  | Platform -> -2147483644l;
-  | Unknown x -> x
+    | Ack -> 1l
+    | Server -> 2l
+    | Unsupported -> -2147483647l
+    | Policy -> -2147483646l
+    | Invalid -> -2147483645l
+    | Platform -> -2147483644l;
+    | Unknown x -> x
 
 end
 
@@ -245,9 +245,9 @@ module Announcement = struct
   type t = [ `V1 | `V2 ] with sexp
 
   cstruct t {
-    uint8_t passwd[8];
-    uint64_t magic;
-  } as big_endian
+      uint8_t passwd[8];
+      uint64_t magic;
+    } as big_endian
 
   let sizeof = sizeof_t
 
@@ -270,9 +270,9 @@ module Announcement = struct
       if magic = v1_magic
       then return `V1
       else
-        if magic = v2_magic
-        then return `V2
-        else `Error (Failure (Printf.sprintf "Bad magic; expected %Ld or %Ld got %Ld" v1_magic v2_magic magic))
+      if magic = v2_magic
+      then return `V2
+      else `Error (Failure (Printf.sprintf "Bad magic; expected %Ld or %Ld got %Ld" v1_magic v2_magic magic))
 end
 
 module Negotiate = struct
@@ -291,14 +291,14 @@ module Negotiate = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   cstruct v1 {
-    uint64_t size;
-    uint32_t flags;
-    uint8_t padding[124]
-  } as big_endian
+      uint64_t size;
+      uint32_t flags;
+      uint8_t padding[124]
+    } as big_endian
 
   cstruct v2 {
-    uint16_t flags;
-  } as big_endian
+      uint16_t flags;
+    } as big_endian
 
   let sizeof = function
     | `V1 -> sizeof_v1
@@ -317,12 +317,12 @@ module Negotiate = struct
     let open Result in
     match t with
     | `V1 ->
-       let size = get_v1_size buf in
-       let flags = PerExportFlag.of_int32 (get_v1_flags buf) in
-       return (V1 { size; flags })
+      let size = get_v1_size buf in
+      let flags = PerExportFlag.of_int32 (get_v1_flags buf) in
+      return (V1 { size; flags })
     | `V2 ->
-       let flags = GlobalFlag.of_int (get_v2_flags buf) in
-       return (V2 flags)
+      let flags = GlobalFlag.of_int (get_v2_flags buf) in
+      return (V2 flags)
 end
 
 module NegotiateResponse = struct
@@ -347,10 +347,10 @@ module OptionRequestHeader = struct
   } with sexp
 
   cstruct t {
-    uint64_t magic;
-    uint32_t ty;
-    uint32_t length;
-  } as big_endian
+      uint64_t magic;
+      uint32_t ty;
+      uint32_t length;
+    } as big_endian
 
   let sizeof = sizeof_t
 
@@ -391,10 +391,10 @@ module DiskInfo = struct
   } with sexp
 
   cstruct t {
-    uint64_t size;
-    uint16_t flags;
-    uint8_t padding[124];
-  } as big_endian
+      uint64_t size;
+      uint16_t flags;
+      uint8_t padding[124];
+    } as big_endian
 
   let sizeof = sizeof_t
 
@@ -413,11 +413,11 @@ end
    should result in reply packets as follows: *)
 module OptionResponseHeader = struct
   cstruct t {
-    uint64_t magic;
-    uint32_t request_type;
-    uint32_t response_type;
-    uint32_t length;
-  } as big_endian
+      uint64_t magic;
+      uint32_t request_type;
+      uint32_t response_type;
+      uint32_t length;
+    } as big_endian
 
   type t = {
     request_type: Option.t;
@@ -456,8 +456,8 @@ module Server = struct
   } with sexp
 
   cstruct t {
-    uint32_t length;
-  } as big_endian
+      uint32_t length;
+    } as big_endian
 
   let sizeof t = sizeof_t + (String.length t.name)
 
@@ -482,12 +482,12 @@ module Request = struct
       (Command.to_string t.ty) t.handle t.from t.len
 
   cstruct t {
-    uint32_t magic;
-    uint32_t ty;
-    uint64_t handle;
-    uint64_t from;
-    uint32_t len
-  } as big_endian
+      uint32_t magic;
+      uint32_t ty;
+      uint64_t handle;
+      uint64_t from;
+      uint32_t len
+    } as big_endian
 
   let unmarshal (buf: Cstruct.t) =
     let open Result in
@@ -510,7 +510,7 @@ module Request = struct
     set_t_from buf t.from;
     set_t_len buf t.len
 end
-	
+
 module Reply = struct
   type t = {
     error : [ `Ok of unit | `Error of Error.t ];
@@ -520,10 +520,10 @@ module Reply = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   cstruct t {
-    uint32_t magic;
-    uint32_t error;
-    uint64_t handle
-  } as big_endian
+      uint32_t magic;
+      uint32_t error;
+      uint64_t handle
+    } as big_endian
 
   let unmarshal (buf: Cstruct.t) =
     let open Result in

--- a/lib/protocol.mli
+++ b/lib/protocol.mli
@@ -18,12 +18,12 @@ module Error: sig
   (** Read and write requests can fail with an error response. *)
 
   type t = [
-  | `EPERM  (** Operation not permitted *)
-  | `EIO    (** Input/output error *)
-  | `ENOMEM (** Cannot allocate memory *)
-  | `EINVAL (** Invalid argument *)
-  | `ENOSPC (** No space left on device *)
-  | `Unknown of int32
+    | `EPERM  (** Operation not permitted *)
+    | `EIO    (** Input/output error *)
+    | `ENOMEM (** Cannot allocate memory *)
+    | `EINVAL (** Invalid argument *)
+    | `ENOSPC (** No space left on device *)
+    | `Unknown of int32
   ] with sexp
   (** Defined error codes which can be returned in response to a request
       in the data-pushing phase. *)
@@ -35,16 +35,16 @@ module Command: sig
   (** Once a connection has been established, the client can submit commands. *)
 
   type t =
-  | Read  (** Read a block of data *)
-  | Write (** Write a block of data *)
-  | Disc  (** Disconnect: server must flush all outstanding commands and then
-              will close the connection *)
-  | Flush (** A flush request or write barrier. All requests received before
-              this one will have completed before this command is acknowledged. *)
-  | Trim  (** A hint that a data region is nolonger required and may be
-              discarded. *)
-  | Unknown of int32 (** A command which this protocol implementation doesn't
-                         suport. *)
+    | Read  (** Read a block of data *)
+    | Write (** Write a block of data *)
+    | Disc  (** Disconnect: server must flush all outstanding commands and then
+                will close the connection *)
+    | Flush (** A flush request or write barrier. All requests received before
+                this one will have completed before this command is acknowledged. *)
+    | Trim  (** A hint that a data region is nolonger required and may be
+                discarded. *)
+    | Unknown of int32 (** A command which this protocol implementation doesn't
+                           suport. *)
   with sexp
 
   val to_string: t -> string
@@ -55,11 +55,11 @@ module PerExportFlag: sig
       be returned from the server when the negotiation is complete. *)
 
   type t =
-  | Read_only   (** export is read/only. Writes will receive EPERM *)
-  | Send_flush  (** server supports Command.Flush *)
-  | Send_fua    (** server supports NBD_CMD_FLAG_FUA *)
-  | Rotational  (** let the client schedule I/O for a rotational medium *)
-  | Send_trim   (** server supports Command.Trim *)
+    | Read_only   (** export is read/only. Writes will receive EPERM *)
+    | Send_flush  (** server supports Command.Flush *)
+    | Send_fua    (** server supports NBD_CMD_FLAG_FUA *)
+    | Rotational  (** let the client schedule I/O for a rotational medium *)
+    | Send_trim   (** server supports Command.Trim *)
   with sexp
   (** Per-export flags *)
 
@@ -150,7 +150,7 @@ module Negotiate: sig
   type t =
     | V1 of v1
     | V2 of v2
-  (** The initial greeting sent by the server *)
+    (** The initial greeting sent by the server *)
 
   val to_string: t -> string
 
@@ -276,7 +276,7 @@ module Reply: sig
 
   type t = {
     error : [ `Ok of unit | `Error of Error.t ]; (** Success or failure of the
-    request *)
+                                                     request *)
     handle : int64; (** The unique id in the [Request] *)
   } with sexp
 

--- a/lib_test/nbd_test.ml
+++ b/lib_test/nbd_test.ml
@@ -15,35 +15,35 @@
 module Nbd = Nbd_unix
 
 let test host port =
-	try
-        let test_str1 = String.make 512 'a' in
-        let test_str2 = String.make 512 'b' in
-        let test_str3 = String.make 512 'c' in
-        let test_str4 = String.make 512 'd' in
-        let test_str5 = String.make 512 'e' in
-        let test_str6 = String.make 512 'f' in
-        let test_str7 = String.make 512 'g' in
-        let test_str8 = String.make 512 'h' in
-		Printf.printf "Connecting...\n";
-		let (sock,sz,flags) = Nbd.connect host port in
-        Printf.printf "Connected: size=%Ld\n" sz;
-        let _ = Nbd.write sock 0L test_str1 0 (String.length test_str1) in
-        let _ = Nbd.write sock 512L test_str2 0 (String.length test_str2)  in
-        let _ = Nbd.write sock 1024L test_str3 0 (String.length test_str3)  in
-        let _ = Nbd.write sock 1536L test_str4 0 (String.length test_str4)  in
-        let _ = Nbd.write sock 2048L test_str5 0 (String.length test_str5)  in
-        let _ = Nbd.write sock 2560L test_str6 0 (String.length test_str6)  in
-        let _ = Nbd.write sock 3072L test_str7 0 (String.length test_str7)  in
-        let _ = Nbd.write sock 3584L test_str8 0 (String.length test_str8)  in
+  try
+    let test_str1 = String.make 512 'a' in
+    let test_str2 = String.make 512 'b' in
+    let test_str3 = String.make 512 'c' in
+    let test_str4 = String.make 512 'd' in
+    let test_str5 = String.make 512 'e' in
+    let test_str6 = String.make 512 'f' in
+    let test_str7 = String.make 512 'g' in
+    let test_str8 = String.make 512 'h' in
+    Printf.printf "Connecting...\n";
+    let (sock,sz,flags) = Nbd.connect host port in
+    Printf.printf "Connected: size=%Ld\n" sz;
+    let _ = Nbd.write sock 0L test_str1 0 (String.length test_str1) in
+    let _ = Nbd.write sock 512L test_str2 0 (String.length test_str2)  in
+    let _ = Nbd.write sock 1024L test_str3 0 (String.length test_str3)  in
+    let _ = Nbd.write sock 1536L test_str4 0 (String.length test_str4)  in
+    let _ = Nbd.write sock 2048L test_str5 0 (String.length test_str5)  in
+    let _ = Nbd.write sock 2560L test_str6 0 (String.length test_str6)  in
+    let _ = Nbd.write sock 3072L test_str7 0 (String.length test_str7)  in
+    let _ = Nbd.write sock 3584L test_str8 0 (String.length test_str8)  in
 
-        Printf.printf "Written\n";
-        let Some str2 = Nbd.read sock 0L 4096l in
-        Printf.printf "%s\n" str2;
-		()
-    with e -> 
-		Printf.printf "Caught exception: %s" (Printexc.to_string e);
-		()
+    Printf.printf "Written\n";
+    let Some str2 = Nbd.read sock 0L 4096l in
+    Printf.printf "%s\n" str2;
+    ()
+  with e -> 
+    Printf.printf "Caught exception: %s" (Printexc.to_string e);
+    ()
 
 let _ =
-	test Sys.argv.(1) (int_of_string Sys.argv.(2))
+  test Sys.argv.(1) (int_of_string Sys.argv.(2))
 

--- a/opam
+++ b/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-version: "2.0.0"
+version: "2.0.1"
 maintainer: "dave@recoil.org"
 authors: [ "Jonathan Ludlam" "David Scott" ]
 license: "LGPL-2 with OCaml linking exception"

--- a/opam
+++ b/opam
@@ -2,11 +2,10 @@ opam-version: "1.2"
 version: "2.0.0"
 maintainer: "dave@recoil.org"
 authors: [ "Jonathan Ludlam" "David Scott" ]
-dev-repo: "git://github.com/xapi-project/nbd"
 license: "LGPL-2 with OCaml linking exception"
-homepage: "https://github.com/mirage/ocaml-qcow"
-dev-repo: "https://github.com/mirage/ocaml-qcow.git"
-bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+homepage: "https://github.com/xapi-project/nbd"
+dev-repo: "https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
 
 build: [
   ["oasis" "setup"]
@@ -38,3 +37,4 @@ depends: [
   "uri"
 ]
 tags: [ "org:mirage" "org:xapi-project" ]
+available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
- remove dead code
- handle the case where the server sends back an unexpected `OptionResponseHeader` (instead of generating a match failed exception)
- add `make reindent` to call `ocp-indent`
- reindent sources
- fix typos in opam file