### PR TITLE
Use standard Result type

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -11,8 +11,9 @@ Library nbd
   Pack: true
   CompiledObject: best
   Path: lib
-  Modules: S, Protocol, Nbd_result, Client, Channel, Server, Mux, Mirror
-  BuildDepends: cstruct, cstruct.ppx, sexplib, ppx_sexp_conv, lwt, mirage-types.lwt, io-page
+  Modules: S, Protocol, Client, Channel, Server, Mux, Mirror
+  BuildDepends: cstruct, cstruct.ppx, sexplib, ppx_sexp_conv, lwt,
+    mirage-types.lwt, io-page, result, rresult
 
 Library "nbd-lwt"
   CompiledObject: best

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -140,13 +140,13 @@ module Impl = struct
       >>= fun channel ->
       Client.list channel
       >>= function
-      | `Ok disks ->
+      | Result.Ok disks ->
         List.iter print_endline disks;
         return ()
-      | `Error `Unsupported ->
+      | Result.Error `Unsupported ->
         Printf.fprintf stderr "The server does not support the query function.\n%!";
         exit 1
-      | `Error `Policy ->
+      | Result.Error `Policy ->
         Printf.fprintf stderr "The server configuration does not permit listing exports.\n%!";
         exit 2 in
     `Ok (Lwt_main.run t)
@@ -209,10 +209,10 @@ let mirror common filename port secondary =
                   Printf.fprintf stderr "Mirror %d %% complete\n%!" x in
               M.connect ~progress_cb primary secondary
               >>= function
-              | `Error e ->
+              | Result.Error e ->
                 Printf.fprintf stderr "Failed to create mirror: %s\n%!" (M.string_of_error e);
                 exit 1
-              | `Ok m ->
+              | Result.Ok m ->
                 return m
             end
         end

--- a/lib/mirror.mli
+++ b/lib/mirror.mli
@@ -17,7 +17,7 @@ module Make(Primary: V1_LWT.BLOCK)(Secondary: V1_LWT.BLOCK): sig
 
   val connect:
     ?progress_cb:([ `Percent of int | `Complete ]-> unit)
-    -> Primary.t -> Secondary.t -> [ `Ok of t | `Error of error ] Lwt.t
+    -> Primary.t -> Secondary.t -> (t, error) Result.result Lwt.t
   (** [connect ?progress primary secondary] creates a block device which performs I/O
       against [primary], while building a mirror of [primary] on top of
       [secondary] in the background. Existing data in [secondary] will be
@@ -26,7 +26,7 @@ module Make(Primary: V1_LWT.BLOCK)(Secondary: V1_LWT.BLOCK): sig
       If [?progress_cb] is provided then it will be called on every percentage
       change in mirror progress.
 
-      It is an error if the block size of either [primary] or [secondary] 
+      It is an error if the block size of either [primary] or [secondary]
       is not an integer multiple of the other.
 
       It is an error if [primary] and [secondary] have different lengths.

--- a/lib/mux.ml
+++ b/lib/mux.ml
@@ -24,7 +24,7 @@ module type RPC = sig
   type response_body
 
   val recv_hdr : transport -> (id option * response_hdr) Lwt.t
-  val recv_body : transport -> request_hdr -> response_hdr -> response_body -> [ `Ok of unit | `Error of Protocol.Error.t ] Lwt.t
+  val recv_body : transport -> request_hdr -> response_hdr -> response_body -> (unit, Protocol.Error.t) Result.result Lwt.t
   val send_one : transport -> request_hdr -> request_body -> unit Lwt.t
   val id_of_request : request_hdr -> id
   val handle_unrequested_packet : transport -> response_hdr -> unit Lwt.t
@@ -38,7 +38,7 @@ module Make = functor (R : RPC) -> struct
   type client = {
     transport : R.transport;
     outgoing_mutex: Lwt_mutex.t;
-    id_to_wakeup : (R.id, R.request_hdr * ([ `Ok of unit | `Error of Protocol.Error.t ] Lwt.u) * R.response_body) Hashtbl.t;
+    id_to_wakeup : (R.id, R.request_hdr * ((unit, Protocol.Error.t) Result.result Lwt.u) * R.response_body) Hashtbl.t;
     mutable dispatcher_thread : unit Lwt.t;
     mutable dispatcher_shutting_down : bool;
   }

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -266,15 +266,15 @@ module Announcement = struct
     let open Nbd_result in
     let passwd = Cstruct.to_string (get_t_passwd buf) in
     if passwd <> expected_passwd
-    then `Error (Failure "Bad magic in negotiate")
+    then Error (Failure "Bad magic in negotiate")
     else
       let magic = get_t_magic buf in
       if magic = v1_magic
-      then return `V1
+      then Ok `V1
       else
       if magic = v2_magic
-      then return `V2
-      else `Error (Failure (Printf.sprintf "Bad magic; expected %Ld or %Ld got %Ld" v1_magic v2_magic magic))
+      then Ok `V2
+      else Error (Failure (Printf.sprintf "Bad magic; expected %Ld or %Ld got %Ld" v1_magic v2_magic magic))
 end
 
 module Negotiate = struct
@@ -324,10 +324,10 @@ module Negotiate = struct
     | `V1 ->
       let size = get_v1_size buf in
       let flags = PerExportFlag.of_int32 (get_v1_flags buf) in
-      return (V1 { size; flags })
+      Ok (V1 { size; flags })
     | `V2 ->
       let flags = GlobalFlag.of_int (get_v2_flags buf) in
-      return (V2 flags)
+      Ok (V2 flags)
 end
 
 module NegotiateResponse = struct
@@ -366,14 +366,14 @@ module OptionRequestHeader = struct
     set_t_length buf t.length
 
   let unmarshal buf =
-    let open Nbd_result in
+    let open Rresult in
     let magic = get_t_magic buf in
     ( if Announcement.v2_magic <> magic
-      then fail (Failure (Printf.sprintf "Bad reply magic: expected %Ld, got %Ld" Announcement.v2_magic magic))
-      else return () ) >>= fun () ->
+      then Error (Failure (Printf.sprintf "Bad reply magic: expected %Ld, got %Ld" Announcement.v2_magic magic))
+      else Ok () ) >>= fun () ->
     let ty = Option.of_int32 (get_t_ty buf) in
     let length = get_t_length buf in
-    return { ty; length }
+    Ok { ty; length }
 end
 
 (* This is the option sent by the client to select a particular disk
@@ -409,7 +409,7 @@ module DiskInfo = struct
     let open Nbd_result in
     let size = get_t_size buf in
     let flags = PerExportFlag.of_int32 (Int32.of_int (get_t_flags buf)) in
-    return { size; flags }
+    Ok { size; flags }
 
   let marshal buf t =
     set_t_size buf t.size;
@@ -440,15 +440,15 @@ module OptionResponseHeader = struct
   let expected_magic = 0x3e889045565a9L
 
   let unmarshal buf =
-    let open Nbd_result in
+    let open Rresult in
     let magic = get_t_magic buf in
     ( if expected_magic <> magic
-      then fail (Failure (Printf.sprintf "Bad reply magic: expected %Ld, got %Ld" expected_magic magic))
-      else return () ) >>= fun () ->
+      then Error (Failure (Printf.sprintf "Bad reply magic: expected %Ld, got %Ld" expected_magic magic))
+      else Ok () ) >>= fun () ->
     let request_type = Option.of_int32 (get_t_request_type buf) in
     let response_type = OptionResponse.of_int32 (get_t_response_type buf) in
     let length = get_t_length buf in
-    return { request_type; response_type; length }
+    Ok { request_type; response_type; length }
 
   let marshal buf t =
     set_t_magic buf expected_magic;
@@ -475,7 +475,7 @@ module Server = struct
     let length = Int32.to_int (get_t_length buf) in
     let buf = Cstruct.shift buf sizeof_t in
     let name = Cstruct.(to_string (sub buf 0 length)) in
-    return { name }
+    Ok { name }
 end
 
 module Request = struct
@@ -500,16 +500,16 @@ module Request = struct
     } [@@big_endian]
   ]
   let unmarshal (buf: Cstruct.t) =
-    let open Nbd_result in
+    let open Rresult in
     let magic = get_t_magic buf in
     ( if nbd_request_magic <> magic
-      then fail (Failure (Printf.sprintf "Bad request magic: expected %ld, got %ld" magic nbd_request_magic))
-      else return () ) >>= fun () ->
+      then Error (Failure (Printf.sprintf "Bad request magic: expected %ld, got %ld" magic nbd_request_magic))
+      else Ok () ) >>= fun () ->
     let ty = Command.of_int32 (get_t_ty buf) in
     let handle = get_t_handle buf in
     let from = get_t_from buf in
     let len = get_t_len buf in
-    return { ty; handle; from; len }
+    Ok { ty; handle; from; len }
 
   let sizeof = sizeof_t
 
@@ -537,15 +537,15 @@ module Reply = struct
     } [@@big_endian]
   ]
   let unmarshal (buf: Cstruct.t) =
-    let open Nbd_result in
+    let open Rresult in
     let magic = get_t_magic buf in
     ( if nbd_reply_magic <> magic
-      then fail (Failure (Printf.sprintf "Bad reply magic: expected %ld, got %ld" magic nbd_reply_magic))
-      else return () ) >>= fun () ->
+      then Error (Failure (Printf.sprintf "Bad reply magic: expected %ld, got %ld" magic nbd_reply_magic))
+      else Ok () ) >>= fun () ->
     let error = get_t_error buf in
     let error = if error = 0l then `Ok () else `Error (Error.of_int32 error) in
     let handle = get_t_handle buf in
-    return { error; handle }
+    Ok { error; handle }
 
   let sizeof = sizeof_t
 

--- a/lib/protocol.mli
+++ b/lib/protocol.mli
@@ -131,7 +131,7 @@ module Announcement: sig
   val sizeof: int
 
   val marshal: Cstruct.t -> t -> unit
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
 end
 
 module Negotiate: sig
@@ -157,7 +157,7 @@ module Negotiate: sig
   val sizeof: Announcement.t -> int
 
   val marshal: Cstruct.t -> t -> unit
-  val unmarshal: Cstruct.t -> Announcement.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> Announcement.t -> (t, exn) Result.result
 end
 
 module NegotiateResponse: sig
@@ -185,7 +185,7 @@ module OptionRequestHeader: sig
   val sizeof: int
 
   val marshal: Cstruct.t -> t -> unit
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
 end
 
 module ExportName: sig
@@ -211,7 +211,7 @@ module DiskInfo: sig
 
   val sizeof: int
 
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
   val marshal: Cstruct.t -> t -> unit
 end
 
@@ -232,7 +232,7 @@ module OptionResponseHeader: sig
 
   val to_string: t -> string
 
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
   val marshal: Cstruct.t -> t -> unit
 end
 
@@ -248,7 +248,7 @@ module Server: sig
 
   val sizeof: t -> int
 
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
 end
 
 module Request: sig
@@ -267,7 +267,7 @@ module Request: sig
   val sizeof: int
 
   val marshal: Cstruct.t -> t -> unit
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
 end
 
 module Reply: sig
@@ -285,6 +285,5 @@ module Reply: sig
   val sizeof: int
 
   val marshal: Cstruct.t -> t -> unit
-  val unmarshal: Cstruct.t -> [ `Ok of t | `Error of exn ]
-
+  val unmarshal: Cstruct.t -> (t, exn) Result.result
 end

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -24,7 +24,7 @@ module type CLIENT = sig
   type size = int64
   (** The size of a remote disk *)
 
-  val list: channel -> [ `Ok of string list | `Error of [ `Policy | `Unsupported ] ] Lwt.t
+  val list: channel -> (string list, [ `Policy | `Unsupported ]) Result.result Lwt.t
   (** [list channel] returns a list of exports known by the server.
       [`Error `Policy] means the server has this function disabled deliberately.
       [`Error `Unsupported] means the server is old and does not support the query

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -58,8 +58,8 @@ let connect channel ?offer () =
     channel.read req
     >>= fun () ->
     match OptionRequestHeader.unmarshal req with
-    | `Error e -> fail e
-    | `Ok hdr ->
+    | Result.Error e -> fail e
+    | Result.Ok hdr ->
       let payload = Cstruct.create (Int32.to_int hdr.OptionRequestHeader.length) in
       channel.read payload
       >>= fun () ->
@@ -111,8 +111,8 @@ let next t =
   t.channel.read t.request
   >>= fun () ->
   match Request.unmarshal t.request with
-  | `Ok r -> return r
-  | `Error e -> fail e
+  | Result.Ok r -> return r
+  | Result.Error e -> fail e
 
 let ok t handle payload =
   Lwt_mutex.with_lock t.m

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -112,7 +112,7 @@ let list_disabled =
       let channel = make_client_channel v2_list_export_disabled in
       Client.list channel
       >>= function
-      | `Error `Policy ->
+      | Result.Error `Policy ->
         return ()
       | _ -> failwith "Expected to receive a Policy error" in
     Lwt_main.run t
@@ -125,7 +125,7 @@ let list_success =
       let channel = make_client_channel v2_list_export_success in
       Client.list channel
       >>= function
-      | `Ok [ "export1" ] ->
+      | Result.Ok [ "export1" ] ->
         return ()
       | _ -> failwith "Expected to receive a list of exports" in
     Lwt_main.run t

--- a/opam
+++ b/opam
@@ -28,6 +28,8 @@ depends: [
   "ocamlfind" {build}
   "ppx_tools" {build}
   "lwt"
+  "result"
+  "rresult"
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"


### PR DESCRIPTION
This patch fixes the build error caused by recent lwt using the now standard definition of `module Result` which then clashes with the `module Result` defined in this package.

Note this changes the public API to use the variant result type rather than the polymorphic variant type.

Signed-off-by: David Scott <dave@recoil.org>