### PR TITLE
NBD server: continue processing requests after write command

### DIFF
--- a/lib/server.ml
+++ b/lib/server.ml
@@ -166,7 +166,7 @@ let serve t (type t) block (b:t) =
             let remaining = remaining - n in
             if remaining > 0
             then copy Int64.(add offset (of_int n)) remaining
-            else ok t handle None in
+            else ok t handle None >>= fun () -> loop () in
         copy from (Int32.to_int request.Request.len)
       end
     | { ty = Command.Read; from; len; handle } ->


### PR DESCRIPTION
Previously, after NBD_CMD_WRITE, the recursive loop wasn't called again,
and this caused clients to hang when they issued any subsequent
commands.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>
(cherry picked from commit 5368f666b4ba5c70b81cccb4e56e3ccd2c4ef539)