### PR TITLE
NBD server: set SO_REUSEADDR on the server socket

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -186,6 +186,7 @@ module Impl = struct
       let sock = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
       Lwt.finalize
         (fun () ->
+           Lwt_unix.setsockopt sock Lwt_unix.SO_REUSEADDR true;
            let sockaddr = Lwt_unix.ADDR_INET(Unix.inet_addr_any, port) in
            Lwt_unix.bind sock sockaddr;
            Lwt_unix.listen sock 5;


### PR DESCRIPTION
To avoid having to wait about 30 seconds until the NBD server can be
started again after shutdown.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>