### PR TITLE
Fix coverage build using jbuilder (and master ppx_bisect)

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -6,22 +6,19 @@ COVERAGE_DIR=.coverage
 rm -rf $COVERAGE_DIR
 mkdir -p $COVERAGE_DIR
 pushd $COVERAGE_DIR
-if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 
 $(which cp) -r ../* .
 
 export COVERAGE=1
 jbuilder runtest
 
-mkdir _outs
-$(find . | grep bisect.*.out | xargs mv -t _outs)
-bisect-ppx-report -I _outs -text report _outs/bisect*.out
-bisect-ppx-report -I _outs -summary-only -text summary _outs/bisect*.out
-(cd _outs; bisect-ppx-report bisect*.out -html ../report-html)
+outs=$(find . | grep bisect.*.out)
+bisect-ppx-report -I $(dirname $outs[1]) -text report $outs
+bisect-ppx-report -I $(dirname $outs[1]) -summary-only -text summary $outs
 
 if [ -n "$TRAVIS" ]; then
   echo "\$TRAVIS set; running ocveralls and sending to coveralls.io..."
-  ocveralls --prefix _outs bisect*.out --send
+  ocveralls --prefix $(dirname $outs[1]) $outs --send
 else
   echo "\$TRAVIS not set; displaying results of bisect-report..."
   cat report

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -9,6 +9,8 @@ pushd $COVERAGE_DIR
 
 $(which cp) -r ../* .
 
+opam install -y bisect_ppx ocveralls
+
 export COVERAGE=1
 jbuilder runtest
 

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -11,6 +11,7 @@ if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 $(which cp) -r ../* .
 
 opam pin add bisect_ppx --dev-repo -y
+opam install ocveralls -y
 
 export COVERAGE=1
 jbuilder runtest

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -10,7 +10,7 @@ if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 
 $(which cp) -r ../* .
 
-opam install -y bisect_ppx ocveralls
+opam pin add bisect_ppx --dev-repo -y
 
 export COVERAGE=1
 jbuilder runtest
@@ -18,6 +18,7 @@ jbuilder runtest
 outs=$(find . | grep bisect.*.out)
 bisect-ppx-report -I $(dirname $outs[1]) -text report $outs
 bisect-ppx-report -I $(dirname $outs[1]) -summary-only -text summary $outs
+if [ -n "$HTML" ]; then bisect-ppx-report -I $(dirname $outs[1]) -html ../html-report $outs; fi
 
 if [ -n "$TRAVIS" ]; then
   echo "\$TRAVIS set; running ocveralls and sending to coveralls.io..."

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -6,6 +6,7 @@ COVERAGE_DIR=.coverage
 rm -rf $COVERAGE_DIR
 mkdir -p $COVERAGE_DIR
 pushd $COVERAGE_DIR
+if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 
 $(which cp) -r ../* .
 

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -23,7 +23,7 @@ if [ -n "$HTML" ]; then bisect-ppx-report -I $(dirname $outs[1]) -html ../html-r
 
 if [ -n "$TRAVIS" ]; then
   echo "\$TRAVIS set; running ocveralls and sending to coveralls.io..."
-  ocveralls --prefix $(dirname $outs[1]) $outs --send
+  ocveralls --prefix _build/default $outs --send
 else
   echo "\$TRAVIS not set; displaying results of bisect-report..."
   cat report

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     # Also, set TESTS to false to avoid running them twice.
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
       TEST=false \
-      POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID COVERAGE=1 bash -ex .coverage.sh"
+      POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex .coverage.sh"
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ env:
     - DISTRO=debian-stable
     - PACKAGE=nbd
   matrix:
-    - BASE_REMOTE=git://github.com/xapi-project/xs-opam
+    # We need to pass some Travis environment variables to the container to
+    # enable uploading to coveralls and detection of Travis CI.
+    # Also, set TESTS to false to avoid running them twice.
+    - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
+      TEST=false \
+      POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID COVERAGE=1 bash -ex .coverage.sh"
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
 matrix:
   fast_finish: true

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -15,11 +15,14 @@ let flags = function
   in
   go ic ""
 
-let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
+let coverage_rewriter ~full =
+  let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false in
+  match is_coverage, full with
+  | true, true -> "(preprocess (pps (bisect_ppx -simple-cases)))"
+  | true, _    -> "bisect_ppx -simple-cases"
+  | _          -> ""
 
-let additional_libraries = if is_coverage then "bisect_ppx" else ""
-let rewriters =
-  ["ppx_sexp_conv"; "cstruct.ppx"] @ (if is_coverage then ["bisect_ppx"] else [])
+let rewriters = ["ppx_sexp_conv"; "cstruct.ppx"]
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
@@ -32,8 +35,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     lwt
     mirage-types.lwt
     ppx_sexp_conv
-    sexplib
-    %s))
-  )
- )
-|} (flags rewriters) additional_libraries
+    sexplib))
+  %s
+  ))
+|} (flags rewriters) (coverage_rewriter ~full:true)

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,7 +1,9 @@
 (* -*- tuareg -*- *)
 #require "unix"
 
-let flags pkgs =
+let flags = function
+| [] -> ""
+| pkgs -> 
   let cmd = "ocamlfind ocamlc -verbose" ^ (
     List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
   ) in
@@ -12,6 +14,12 @@ let flags pkgs =
     try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
   in
   go ic ""
+
+let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
+
+let additional_libraries = if is_coverage then "bisect_ppx" else ""
+let rewriters =
+  ["ppx_sexp_conv"; "cstruct.ppx"] @ (if is_coverage then ["bisect_ppx"] else [])
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
@@ -24,7 +32,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     lwt
     mirage-types.lwt
     ppx_sexp_conv
-    sexplib))
+    sexplib
+    %s))
   )
  )
-|} (flags ["ppx_sexp_conv"; "cstruct.ppx"])
+|} (flags rewriters) additional_libraries

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -25,8 +25,7 @@ let coverage_rewriter ~full =
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
  ((name test)
-  (flags (:standard))
-  (libraries (nbd.lwt oUnit))
+  (libraries (lwt.unix nbd oUnit))
   %s
   ))
 

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,9 +1,34 @@
+(* -*- tuareg -*- *)
+#require "unix"
+
+let flags = function
+| [] -> ""
+| pkgs -> 
+  let cmd = "ocamlfind ocamlc -verbose" ^ (
+    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
+  ) in
+  let ic = Unix.open_process_in
+    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\w+)'")
+  in
+  let rec go ic acc =
+    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
+  in
+  go ic ""
+
+let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
+
+let additional_libraries = if is_coverage then "bisect_ppx" else ""
+let rewriters = (if is_coverage then ["bisect_ppx"] else [])
+
+let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
  ((name test)
-  (libraries (nbd.lwt oUnit))
+  (flags (:standard -linkall %s))
+  (libraries (nbd.lwt oUnit %s))
   ))
 
 (alias
  ((name   runtest)
   (deps   (test.exe))
   (action (run ${<} -runner sequential))))
+|} (flags rewriters) additional_libraries

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -15,20 +15,23 @@ let flags = function
   in
   go ic ""
 
-let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
-
-let additional_libraries = if is_coverage then "bisect_ppx" else ""
-let rewriters = (if is_coverage then ["bisect_ppx"] else [])
+let coverage_rewriter ~full =
+  let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false in
+  match is_coverage, full with
+  | true, true -> "(preprocess (pps (bisect_ppx -simple-cases)))"
+  | true, _    -> "bisect_ppx -simple-cases"
+  | _          -> ""
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
  ((name test)
-  (flags (:standard -linkall %s))
-  (libraries (nbd.lwt oUnit %s))
+  (flags (:standard))
+  (libraries (nbd.lwt oUnit))
+  %s
   ))
 
 (alias
  ((name   runtest)
   (deps   (test.exe))
   (action (run ${<} -runner sequential))))
-|} (flags rewriters) additional_libraries
+|} (coverage_rewriter ~full:true)

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,6 +1,31 @@
+(* -*- tuareg -*- *)
+#require "unix"
+
+let flags = function
+| [] -> ""
+| pkgs -> 
+  let cmd = "ocamlfind ocamlc -verbose" ^ (
+    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
+  ) in
+  let ic = Unix.open_process_in
+    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\w+)'")
+  in
+  let rec go ic acc =
+    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
+  in
+  go ic ""
+
+let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
+
+let additional_libraries = if is_coverage then "bisect_ppx" else ""
+let rewriters =
+  ["ppx_sexp_conv"; "cstruct.ppx"] @ (if is_coverage then ["bisect_ppx"] else [])
+
+let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name nbd_lwt_unix)
   (public_name nbd.lwt)
+  (flags (:standard %s))
   (libraries
    (cstruct.lwt
     io-page
@@ -8,5 +33,7 @@
     lwt
     lwt.unix
     mirage-types.lwt
-    nbd))
+    nbd
+    %s))
  ))
+|} (flags rewriters) additional_libraries

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,3 +1,28 @@
+(* -*- tuareg -*- *)
+#require "unix"
+
+let flags = function
+| [] -> ""
+| pkgs -> 
+  let cmd = "ocamlfind ocamlc -verbose" ^ (
+    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
+  ) in
+  let ic = Unix.open_process_in
+    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\w+)'")
+  in
+  let rec go ic acc =
+    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
+  in
+  go ic ""
+
+let coverage_rewriter ~full =
+  let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false in
+  match is_coverage, full with
+  | true, true -> "(preprocess (pps (bisect_ppx -simple-cases)))"
+  | true, _    -> "bisect_ppx -simple-cases"
+  | _          -> ""
+
+let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name nbd_lwt_unix)
   (public_name nbd.lwt)
@@ -9,4 +34,6 @@
     lwt.unix
     mirage-types.lwt
     nbd))
+  %s
   ))
+|} (coverage_rewriter ~full:true)

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -15,11 +15,14 @@ let flags = function
   in
   go ic ""
 
-let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false
+let coverage_rewriter ~full =
+  let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false in
+  match is_coverage, full with
+  | true, true -> "(preprocess (pps (bisect_ppx -simple-cases)))"
+  | true, _    -> "bisect_ppx -simple-cases"
+  | _          -> ""
 
-let additional_libraries = if is_coverage then "bisect_ppx" else ""
-let rewriters =
-  ["ppx_sexp_conv"; "cstruct.ppx"] @ (if is_coverage then ["bisect_ppx"] else [])
+let rewriters = ["ppx_sexp_conv"; "cstruct.ppx"]
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
@@ -33,7 +36,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     lwt
     lwt.unix
     mirage-types.lwt
-    nbd
-    %s))
- ))
-|} (flags rewriters) additional_libraries
+    nbd))
+  %s
+  ))
+|} (flags rewriters) (coverage_rewriter ~full:true)

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -22,13 +22,10 @@ let coverage_rewriter ~full =
   | true, _    -> "bisect_ppx -simple-cases"
   | _          -> ""
 
-let rewriters = ["ppx_sexp_conv"; "cstruct.ppx"]
-
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name nbd_lwt_unix)
   (public_name nbd.lwt)
-  (flags (:standard %s))
   (libraries
    (cstruct.lwt
     io-page
@@ -39,4 +36,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     nbd))
   %s
   ))
-|} (flags rewriters) (coverage_rewriter ~full:true)
+|} (coverage_rewriter ~full:true)

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,28 +1,3 @@
-(* -*- tuareg -*- *)
-#require "unix"
-
-let flags = function
-| [] -> ""
-| pkgs -> 
-  let cmd = "ocamlfind ocamlc -verbose" ^ (
-    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
-  ) in
-  let ic = Unix.open_process_in
-    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\w+)'")
-  in
-  let rec go ic acc =
-    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
-  in
-  go ic ""
-
-let coverage_rewriter ~full =
-  let is_coverage = try Unix.getenv "COVERAGE" = "1" with Not_found -> false in
-  match is_coverage, full with
-  | true, true -> "(preprocess (pps (bisect_ppx -simple-cases)))"
-  | true, _    -> "bisect_ppx -simple-cases"
-  | _          -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name nbd_lwt_unix)
   (public_name nbd.lwt)
@@ -34,6 +9,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     lwt.unix
     mirage-types.lwt
     nbd))
-  %s
   ))
-|} (coverage_rewriter ~full:true)


### PR DESCRIPTION
Until https://github.com/janestreet/jbuilder/issues/57 is resolved we
can still make coverage builds by adding the necessary flags by hand, as
we are doing for the "old style" ppx derivers.

We watch the value of the `COVERAGE` environment variable. If this is
defined and set to "1", we inject the necessary `ppx_bisect` flags and
dependencies in the generated jbuild file.

The boilerplate necessary is generic and can be used with minimal or no
changes in most of our other packages.

Once the necessary changes are landed in jbuilder and ppx_bisect, we can
update the project simply updating the jbuild files only.