### PR TITLE
[bugfix-v2.x] Prepare to release 2.2.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+2.2.0 (2017-08-02):
+* Port to jbuilder
+
+* NBD client:
+  * Fix marshalling of client flags
+
+* NBD server:
+  * Fix unmarshalling of client flags
+  * Fix a bug where the server stopped processing requests after an
+    NBD_CMD_WRITE command
+  * Handle NBD_CMD_DISC correctly instead of returning EINVAL
+
+* nbd-tool's "serve" command:
+  * Set SO_REUSEADDR on the server socket to allow quick restart
+  * Make it more robust by ensuring that no open file descriptors are leaked
+  * Don't stop the server when handling one client fails
+
 2.1.3 (2017-02-14):
 * Fix a memory leak in the dispatcher
 


### PR DESCRIPTION
Note that we've been using the NBD client from this library in xapi, and in other components too. I've tested the reverse dependencies in xs-opam and they still compile. After this PR is merged, I'll update it in xs-opam.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>