### PR TITLE
nbd.opam: require cstruct 2.3.0 instead of 2.4.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2.3.1 (2017-09-06):
+* nbd.opam: require cstruct 2.3.0 instead of 2.4.0
+
 2.3.0 (2017-09-05):
 * TLS support (libs and server only)
 * New functions for ease of safe use

--- a/nbd.opam
+++ b/nbd.opam
@@ -13,7 +13,7 @@ depends: [
   "ounit" {test}
   "lwt" {>= "2.6.0" & < "3.0.0"}
   "ssl"
-  "cstruct" {>= "2.4.0" & < "3.0.0"}
+  "cstruct" {>= "2.3.0" & < "3.0.0"}
   "cmdliner"
   "sexplib"
   "mirage-block-unix" {< "2.5.0"}


### PR DESCRIPTION
to sync the opam file with the one in xs-opam. And prepare a new bugfix release with the fixed `opam` file.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>