### PR TITLE
nbd.opam: make ppx_sexp_conv bound less restrictive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2.3.2 (2017-09-06):
+* nbd.opam: make ppx_sexp_conv bound less restrictive
+
 2.3.1 (2017-09-06):
 * nbd.opam: require cstruct 2.3.0 instead of 2.4.0
 

--- a/nbd.opam
+++ b/nbd.opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-types-lwt" {= "2.8.0"}
   "mirage-types" {= "2.8.0"}
   "uri"
-  "ppx_sexp_conv" {= "113.33.01+4.03"}
+  "ppx_sexp_conv" {>= "113.33.01+4.03" & < "v0.9.0"}
 ]
 tags: [ "org:xapi-project" ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
And make a new release.