### PR TITLE
Enhance NBD client tests and reorganize test modules

### DIFF
--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,9 +1,9 @@
 (executable
- ((name test)
+ ((name suite)
   (libraries (lwt.unix nbd oUnit))
   ))
 
 (alias
  ((name   runtest)
-  (deps   (test.exe))
+  (deps   (suite.exe))
   (action (run ${<} -runner sequential))))

--- a/lib_test/mux_test.ml
+++ b/lib_test/mux_test.ml
@@ -171,3 +171,12 @@ let test_exception_handling =
       Lwt.catch  (fun () -> t1 >>= function Ok _ -> Lwt.return false | Error _ -> Lwt.return true)
         (fun e -> Printf.printf "Exception: %s\n%!" (Printexc.to_string e); Lwt.return true)
     in assert_bool "Exception handled" (Lwt_main.run t)
+
+let tests =
+  "Mux tests" >:::
+    [ test_rpc
+    ; test_multi_rpc
+    ; test_out_of_order_responses
+    ; test_memory_leak
+    ; test_exception_handling
+    ]

--- a/lib_test/protocol_test.ml
+++ b/lib_test/protocol_test.ml
@@ -131,18 +131,9 @@ let list_success =
       | _ -> failwith "Expected to receive a list of exports" in
     Lwt_main.run t
 
-let negotiate_suite =
-  let open Mux_test in
-  "Nbd suite" >::: [
+let tests =
+  "Nbd client tests" >::: [
     client_negotiation;
     list_disabled;
     list_success;
-    test_rpc;
-    test_multi_rpc;
-    test_out_of_order_responses;
-    test_memory_leak;
-    test_exception_handling;
   ]
-
-let _ =
-  OUnit2.run_test_tt_main (ounit2_of_ounit1 negotiate_suite)

--- a/lib_test/protocol_test.ml
+++ b/lib_test/protocol_test.ml
@@ -17,25 +17,27 @@ open Nbd
 open Lwt
 open Result
 
+(* All the flags in the NBD protocol are in network byte order (big-endian) *)
+
 let v2_negotiation = [
   `Server "NBDMAGIC";
   `Server "IHAVEOPT";
-  `Server "\000\003";
-  `Client "\000\000\000\000";
+  `Server "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+  `Client "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
   `Client "IHAVEOPT";
   `Client "\000\000\000\001"; (* NBD_OPT_EXPORT_NAME *)
   `Client "\000\000\000\007";
   `Client "export1";
   `Server "\000\000\000\000\001\000\000\000"; (* size *)
-  `Server "\000\000"; (* flags *)
+  `Server "\000\000"; (* transmission flags *)
   `Server (String.make 124 '\000');
 ]
 
 let v2_list_export_disabled = [
   `Server "NBDMAGIC"; (* read *)
   `Server "IHAVEOPT";
-  `Server "\000\003";
-  `Client "\000\000\000\000";
+  `Server "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+  `Client "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
   `Client "IHAVEOPT";
   `Client "\000\000\000\003"; (* NBD_OPT_LIST *)
   `Client "\000\000\000\000";
@@ -48,8 +50,8 @@ let v2_list_export_disabled = [
 let v2_list_export_success = [
   `Server "NBDMAGIC"; (* read *)
   `Server "IHAVEOPT";
-  `Server "\000\003";
-  `Client "\000\000\000\000";
+  `Server "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+  `Client "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
   `Client "IHAVEOPT";
   `Client "\000\000\000\003"; (* NBD_OPT_LIST *)
   `Client "\000\000\000\000";
@@ -67,8 +69,8 @@ let v2_list_export_success = [
   `Server "\000\000\000\000";
 ]
 
-let make_client_channel n =
-  let next = ref n in
+let make_client_channel test_sequence =
+  let next = ref test_sequence in
   let rec read buf = match !next with
     | `Server x :: rest ->
       let available = min (Cstruct.len buf) (String.length x) in
@@ -84,7 +86,9 @@ let make_client_channel n =
     | `Server _ :: _ -> fail (Failure "Client tried to write but it should have read")
     | `Client x :: rest ->
       let available = min (Cstruct.len buf) (String.length x) in
-      Cstruct.blit_from_string x 0 buf 0 available;
+      let written = String.sub (Cstruct.to_string buf) 0 available in
+      let expected = String.sub x 0 available in
+      OUnit.assert_equal ~msg:(Printf.sprintf "client wrote bytes: '%s' (length: %d), expected: '%s' (length: %d)" (String.escaped written) (String.length written) (String.escaped expected) (String.length expected)) expected written;
       next := if available = String.length x then rest else `Client (String.sub x available (String.length x - available)) :: rest;
       let buf = Cstruct.shift buf available in
       if Cstruct.len buf = 0

--- a/lib_test/suite.ml
+++ b/lib_test/suite.ml
@@ -1,0 +1,10 @@
+open OUnit
+
+let tests =
+  "Nbd library test suite" >:::
+    [ Mux_test.tests
+    ; Protocol_test.tests
+    ]
+
+let () =
+  OUnit2.run_test_tt_main (ounit2_of_ounit1 tests)


### PR DESCRIPTION
Now the tests check that the client wrote the expected output to the
channel, and that it correctly handles the fixed-newstyle handshake and
client flags.