### PR TITLE
Make client use the cleartext_channel type

### DIFF
--- a/lib/s.ml
+++ b/lib/s.ml
@@ -25,13 +25,13 @@ module type CLIENT = sig
   type size = int64
   (** The size of a remote disk *)
 
-  val list: channel -> [ `Ok of string list | `Error of [ `Policy | `Unsupported ] ] Lwt.t
+  val list: cleartext_channel -> [ `Ok of string list | `Error of [ `Policy | `Unsupported ] ] Lwt.t
   (** [list channel] returns a list of exports known by the server.
       [`Error `Policy] means the server has this function disabled deliberately.
       [`Error `Unsupported] means the server is old and does not support the query
       function. *)
 
-  val negotiate: channel -> string -> (t * size * Protocol.PerExportFlag.t list) Lwt.t
+  val negotiate: cleartext_channel -> string -> (t * size * Protocol.PerExportFlag.t list) Lwt.t
   (** [negotiate channel export] takes an already-connected channel,
       performs the initial protocol negotiation and connects to
       the named export. Returns [disk * remote disk size * flags] *)

--- a/lib_test/protocol_test.ml
+++ b/lib_test/protocol_test.ml
@@ -95,7 +95,7 @@ let make_client_channel test_sequence =
       else write buf
     | [] -> Lwt.fail_with "Client tried to write but the stream was empty" in
   let close () = Lwt.return () in
-  Channel.{ read; write; close; is_tls=false }
+  Channel.{ read_clear=read; write_clear=write; close_clear=close; make_tls_channel=None }
 
 let client_negotiation =
   "Perform a negotiation using the second version of the protocol from the

--- a/lwt/nbd_lwt_unix.ml
+++ b/lwt/nbd_lwt_unix.ml
@@ -99,7 +99,7 @@ let connect hostname port =
   let server_address = host_info.Lwt_unix.h_addr_list.(0) in
   Lwt_unix.connect socket (Lwt_unix.ADDR_INET (server_address, port))
   >>= fun () ->
-  (generic_channel_of_fd socket None)
+  Lwt.return (cleartext_channel_of_fd socket None)
 
 let init_tls_get_ctx ~certfile ~ciphersuites =
   Ssl_threads.init ();

--- a/lwt/nbd_lwt_unix.mli
+++ b/lwt/nbd_lwt_unix.mli
@@ -20,7 +20,7 @@ type tls_role =
   | TlsClient of Ssl.context
   | TlsServer of Ssl.context
 
-val connect: string -> int -> Channel.channel Lwt.t
+val connect: string -> int -> Channel.cleartext_channel Lwt.t
 (** [connect hostname port] connects to host:port and returns
     a [generic_channel] with no TLS ability or potential. *)
 


### PR DESCRIPTION
After https://github.com/xapi-project/nbd/pull/70 , this is required for the correctness of client types, because we always
start with a cleartext channel, and then negotiate the upgrade to TLS. So the client should accept a `cleartext_channel`, and not a `generic_channel`.

If this is merged, I'll also port it to the main branch.