### PR TITLE
Server.serve: set read_only to true by default for safety

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -178,7 +178,7 @@ module Impl = struct
                   clearchan
                   (fun _exportname svr ->
                      Nbd_lwt_unix.with_block filename
-                       (fun b -> Server.serve svr (module Block) b)
+                       (fun b -> Server.serve svr ~read_only:false (module Block) b)
                   )
              )
         )

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -184,7 +184,7 @@ let error t handle code =
        t.channel.write t.reply
     )
 
-let serve t (type t) ?(read_only=false) block (b:t) =
+let serve t (type t) ?(read_only=true) block (b:t) =
   let section = Lwt_log_core.Section.make("Server.serve") in
   let module Block = (val block: V1_LWT.BLOCK with type t = t) in
 


### PR DESCRIPTION
This will not have a significant impact on existing users of the
library, because write access did not work until recently.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>