### PR TITLE
[port to master from bugfix-v2.x] Add parameter for serving exports as read-only

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -183,7 +183,7 @@ module Impl = struct
                   clearchan
                   (fun _exportname svr ->
                      Nbd_lwt_unix.with_block filename
-                       (Server.serve svr (module Block))
+                       (Server.serve svr ~read_only:false (module Block))
                   )
              )
         )

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -64,9 +64,13 @@ module type SERVER = sig
       application. If the name is invalid, the only option is to close the connection.
       If the name is valid then use the [serve] function. *)
 
-  val serve : t ->  (module Mirage_block_lwt.S with type t = 'b) -> 'b -> unit Lwt.t
-  (** [serve t block b] runs forever processing requests from [t], using [block]
-      device type [b]. *)
+  val serve : t -> ?read_only:bool -> (module Mirage_block_lwt.S with type t = 'b) -> 'b -> unit Lwt.t
+  (** [serve t read_only block b] runs forever processing requests from [t], using [block]
+      device type [b]. If [read_only] is true, which is the default, the
+      [block] device [b] is served in read-only mode: the server will set the
+      NBD_FLAG_READ_ONLY transmission flag, and if the client issues a write
+      command, the server will send an EPERM error to the client and will
+      terminate the session. *)
 
   val close: t -> unit Lwt.t
   (** [close t] shuts down the connection [t] and frees any allocated resources *)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -185,19 +185,23 @@ let error t handle code =
        t.channel.write t.reply
     )
 
-let serve t (type t) block (b:t) =
+let serve t (type t) ?(read_only=true) block (b:t) =
   let section = Lwt_log_core.Section.make("Server.serve") in
   let module Block = (val block: Mirage_block_lwt.S with type t = t) in
 
-  Lwt_log_core.notice ~section "Serving new client" >>= fun () ->
+  Lwt_log_core.notice_f ~section "Serving new client, read_only = %b" read_only >>= fun () ->
 
   Block.get_info b
   >>= fun info ->
   let size = Int64.(mul info.Mirage_block.size_sectors (of_int info.Mirage_block.sector_size)) in
-  (if info.Mirage_block.read_write then Lwt.return [] else
-     Lwt_log_core.warning ~section "Block is read-only, sending NBD_FLAG_READ_ONLY transmission flag" >>= fun () ->
-     Lwt.return [ PerExportFlag.Read_only ])
-  >>= fun flags ->
+  (match read_only, info.Mirage_block.read_write with
+   | true, _ -> Lwt.return true
+   | false, true -> Lwt.return false
+   | false, false ->
+     Lwt_log_core.error ~section "Read-write access was requested, but block is read-only, sending NBD_FLAG_READ_ONLY transmission flag" >>= fun () ->
+     Lwt.return true)
+  >>= fun read_only ->
+  let flags = if read_only then [ PerExportFlag.Read_only ] else [] in
   negotiate_end t size flags
   >>= fun t ->
 
@@ -209,7 +213,9 @@ let serve t (type t) block (b:t) =
     let open Request in
     match request with
     | { ty = Command.Write; from; len; handle } ->
-      if Int64.(rem from (of_int info.Mirage_block.sector_size)) <> 0L || Int64.(rem (of_int32 len) (of_int info.Mirage_block.sector_size) <> 0L)
+      if read_only
+      then error t handle `EPERM
+      else if Int64.(rem from (of_int info.Mirage_block.sector_size)) <> 0L || Int64.(rem (of_int32 len) (of_int info.Mirage_block.sector_size) <> 0L)
       then error t handle `EINVAL
       else begin
         let rec copy offset remaining =

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -236,6 +236,15 @@ let serve t (type t) ?(read_only=true) block (b:t) =
         copy from (Int32.to_int request.Request.len)
       end
     | { ty = Command.Read; from; len; handle } ->
+      (* It is okay to disconnect here in case of errors. The NBD protocol
+         documentation says about NBD_CMD_READ:
+         "If an error occurs, the server SHOULD set the appropriate error code
+         in the error field. The server MAY then initiate a hard disconnect.
+         If it chooses not to, it MUST NOT send any payload for this request.
+         If an error occurs while reading after the server has already sent out
+         the reply header with an error field set to zero (i.e., signalling no
+         error), the server MUST immediately initiate a hard disconnect; it
+         MUST NOT send any further data to the client." *)
       if Int64.(rem from (of_int info.Mirage_block.sector_size)) <> 0L || Int64.(rem (of_int32 len) (of_int info.Mirage_block.sector_size) <> 0L)
       then error t handle `EINVAL
       else begin
@@ -247,12 +256,6 @@ let serve t (type t) ?(read_only=true) block (b:t) =
           Block.read b Int64.(div offset (of_int info.Mirage_block.sector_size)) [ subblock ]
           >>= function
           | Error e ->
-            (* The NBD protocol documentation says about NBD_CMD_READ:
-               "If an error occurs while reading after the server has already
-               sent out the reply header with an error field set to zero (i.e.,
-               signalling no error), the server MUST immediately initiate a
-               hard disconnect; it MUST NOT send any further data to the
-               client." *)
             Lwt.fail_with (Printf.sprintf "Partial failure during a Block.read: %s; terminating the session" (Fmt.to_to_string Block.pp_error e))
           | Ok () ->
             t.channel.write subblock


### PR DESCRIPTION
This PR ports the following PRs to master from the bugfix-v2.x branch that have already been reviewed:
* https://github.com/xapi-project/nbd/pull/107
* https://github.com/xapi-project/nbd/pull/109

The read-only parameter itself might change when we finalize the new interface of the library.