### PR TITLE
Revert "CP-24919: Optional timeout for channel IO"

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -48,5 +48,3 @@ let generic_of_cleartext_channel ch = {
   close = ch.close_clear;
   is_tls = false;
 }
-
-exception Timeout of float

--- a/lib/channel.mli
+++ b/lib/channel.mli
@@ -42,6 +42,3 @@ type channel = generic_channel
 val generic_of_tls_channel: tls_channel -> generic_channel
 
 val generic_of_cleartext_channel: cleartext_channel -> generic_channel
-
-exception Timeout of float
-(** An exception to be raised when a read or write exceeds a timeout (seconds) *)

--- a/lwt/nbd_lwt_unix.ml
+++ b/lwt/nbd_lwt_unix.ml
@@ -54,22 +54,7 @@ let io_complete op fd buffer =
   then Lwt.fail End_of_file
   else return ()
 
-let impatient ?timeout_seconds f buf =
-  let timeout timeout_seconds =
-    Lwt_unix.sleep timeout_seconds >>= fun () ->
-    let msg = Printf.sprintf "Closing connection due to IO timeout: %f seconds" timeout_seconds in
-    Lwt_log.warning msg >>= fun () ->
-    Lwt.fail (Channel.Timeout timeout_seconds)
-  in
-  match timeout_seconds with
-  | None -> f buf
-  | Some interval -> (
-    if interval < 1.0e-9
-    then Lwt.fail_invalid_arg (Printf.sprintf "Timeout must be at least one nanosecond; got %f s." interval)
-    else Lwt.pick [timeout interval; f buf]
-  )
-
-let tls_channel_of_fd ?timeout_seconds fd role () =
+let tls_channel_of_fd fd role () =
   let ctx, ssl_start =
     match role with
       | TlsClient ctx -> ctx, Lwt_ssl.ssl_connect
@@ -89,28 +74,21 @@ let tls_channel_of_fd ?timeout_seconds fd role () =
     ignore (Lwt_ssl.ssl_shutdown sock);
     Lwt_ssl.close sock in
 
-  return {
-    read_tls = impatient ?timeout_seconds read_tls;
-    write_tls = impatient ?timeout_seconds write_tls;
-    close_tls
-  }
+  return { read_tls; write_tls; close_tls }
 
 
-let cleartext_channel_of_fd ?timeout_seconds fd role_opt =
+let cleartext_channel_of_fd fd role_opt =
   let read_clear = Lwt_cstruct.(complete (read fd)) in
   let write_clear = Lwt_cstruct.(complete (write fd)) in
   let close_clear () = Lwt_unix.close fd in
   let make_tls_channel = match role_opt with
     | None -> None
-    | Some role -> Some (tls_channel_of_fd ?timeout_seconds fd role)
+    | Some role -> Some (tls_channel_of_fd fd role)
   in
-  {
-    read_clear = impatient ?timeout_seconds read_clear;
-    write_clear = impatient ?timeout_seconds write_clear;
-    close_clear; make_tls_channel }
+  { read_clear; write_clear; close_clear; make_tls_channel }
 
-let generic_channel_of_fd ?timeout_seconds fd role =
-  let ch = cleartext_channel_of_fd ?timeout_seconds fd role
+let generic_channel_of_fd fd role =
+  let ch = cleartext_channel_of_fd fd role
   in return (Channel.generic_of_cleartext_channel ch)
 
 (* This function is used by the client. The channel has no TLS ability. *)
@@ -144,8 +122,8 @@ let with_block filename f =
 
 let ignore_exn t () = Lwt.catch t (fun _ -> Lwt.return_unit)
 
-let with_channel ?timeout_seconds fd tls_role f =
-  let clearchan = cleartext_channel_of_fd ?timeout_seconds fd tls_role in
+let with_channel fd tls_role f =
+  let clearchan = cleartext_channel_of_fd fd tls_role in
   Lwt.finalize
     (fun () -> f clearchan)
     (* We use ignore_exn lest clearchan was closed already by f. *)

--- a/lwt/nbd_lwt_unix.mli
+++ b/lwt/nbd_lwt_unix.mli
@@ -24,16 +24,9 @@ val connect: string -> int -> Channel.channel Lwt.t
 (** [connect hostname port] connects to host:port and returns
     a [generic_channel] with no TLS ability or potential. *)
 
-val cleartext_channel_of_fd :
-  ?timeout_seconds:float ->
-  Lwt_unix.file_descr ->
-  tls_role option ->
-  Nbd.Channel.cleartext_channel
+val cleartext_channel_of_fd: Lwt_unix.file_descr -> tls_role option -> Channel.cleartext_channel
 (** [cleartext_channel_of_fd fd role] returns a channel from an existing file descriptor.
-    The channel will have a [make_tls_channel] value that corresponds to [role].
-    If [timeout_seconds] is supplied, if it is less than 1.0e-9 an Invalid_argument exn is
-    raised; if it is at least a nanosecond it is used for each read and write.
-    If a read/write reaches the timeout, exn [Channel.Timeout timeout_seconds] is raised. *)
+    The channel will have a [make_tls_channel] value that corresponds to [role]. *)
 
 val init_tls_get_ctx: certfile:string -> ciphersuites:string -> Ssl.context
 (** Initialise the Ssl (TLS) library and then create and return a new context. *)
@@ -43,17 +36,13 @@ val with_block: string -> (Block.t -> 'a Block.io) -> 'a Block.io
     with a guarantee to call [Block.disconnect] afterwards. *)
 
 val with_channel:
-  ?timeout_seconds:float ->
   Lwt_unix.file_descr ->
   tls_role option ->
   (Nbd.Channel.cleartext_channel -> 'a Block.io) ->
   'a Block.io
 (** [with_channel fd role f] calls [cleartext_channel_of_fd fd role] then
     applies [f] to the resulting channel, with a guarantee to call
-    the channel's [close_clear] function afterwards.
-    If [timeout_seconds] is supplied, if it is less than 1.0e-9 an Invalid_argument exn is
-    raised; if it is at least a nanosecond it is used for each read and write.
-    If a read/write reaches the timeout, exn [Channel.Timeout timeout_seconds] is raised. *)
+    the channel's [close_clear] function afterwards. *)
 
 module Client: S.CLIENT
 (** A client allows you to access remote disks *)


### PR DESCRIPTION
Reverts xapi-project/nbd#114

We're moving to the master branch, so we should put this there. I also made a mistake when I benchmarked this - I measured without a timeout, because the CLI does not use it.