### PR TITLE
jbuild: add missing lwt_log

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -17,6 +17,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    (cstruct
     io-page
     lwt
+    lwt_log
     mirage-block
     mirage-block-lwt
     mirage-types-lwt

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -4,6 +4,7 @@
    (alcotest
     io-page-unix
     lwt.unix
+    lwt_log
     nbd))
   ))
 


### PR DESCRIPTION
This patch should be backward compatible

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>