### PR TITLE
Fix doc upload

### DIFF
--- a/.docgen.sh
+++ b/.docgen.sh
@@ -28,7 +28,7 @@ rm -rf $DOCDIR
 # Don't expose GH_TOKEN
 git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/xapi-project/nbd $DOCDIR > /dev/null 2>&1
 git -C $DOCDIR rm -rf .
-cp -r _build/default/_doc/* $DOCDIR
+cp -r _build/default/_doc/_html/* $DOCDIR
 git -C $DOCDIR config user.email "travis@travis-ci.org"
 git -C $DOCDIR config user.name "Travis"
 (cd $DOCDIR; git add *)


### PR DESCRIPTION
The output of "make doc" has changed, now the HTML docs are in the _html
subdirectory.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>