### PR TITLE
CP-29049: Fix list and abort behaviour and expand protocol tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   # when POST_INSTALL_HOOK is run, even if TESTS is set to true.
   - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.06 \
     TEST=false \
-    POST_INSTALL_HOOK="opam install alcotest io-page-unix; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
+    POST_INSTALL_HOOK="opam install alcotest alcotest-lwt io-page-unix; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
   - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.07
   # Upload docs for both nbd and nbd-lwt-unix
   - PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.06 SCRIPT=.travis-docker-docgen.sh

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -2,6 +2,7 @@
  ((name suite)
   (libraries
    (alcotest
+    alcotest-lwt
     io-page-unix
     lwt.unix
     lwt_log

--- a/lib_test/protocol_test.ml
+++ b/lib_test/protocol_test.ml
@@ -12,11 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(** This module tests the core NBD library by verifying that the communication
+(** Tests that the client and server correctly implement the NBD protocol:
+    https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md
+
+    This module tests the core NBD library by verifying that the communication
     between the client and the server exactly matches the specified test
     sequences. *)
 
-open Nbd
 open Lwt.Infix
 
 (** An Alcotest TESTABLE for the data transmissions in the test sequences *)
@@ -50,6 +52,7 @@ exception Failed_to_read_empty_stream
 let make_channel role test_sequence =
   let next = ref test_sequence in
   let rec read buf =
+    Lwt_io.printlf "Reading %d bytes" (Cstruct.len buf) >>= fun () ->
     (* Ignore reads and writes of length 0 and treat them as a no-op *)
     if Cstruct.len buf = 0 then Lwt.return_unit else
       match !next with
@@ -58,12 +61,15 @@ let make_channel role test_sequence =
         let available = min (Cstruct.len buf) (String.length x) in
         Cstruct.blit_from_string x 0 buf 0 available;
         next := if available = String.length x then rest else (source, (String.sub x available (String.length x - available))) :: rest;
+        Lwt_io.printlf "Read: %s" (x |> String.escaped) >>= fun () ->
+        Lwt_io.flush_all () >>= fun () -> (* Ensure all debug messages get logged *)
         let buf = Cstruct.shift buf available in
         if Cstruct.len buf = 0
         then Lwt.return ()
         else read buf
       | [] -> Lwt.fail Failed_to_read_empty_stream in
   let rec write buf =
+    Lwt_io.printlf "Writing: %s" (buf |> Cstruct.to_string |> String.escaped) >>= fun () ->
     (* Ignore reads and writes of length 0 and treat them as a no-op *)
     if Cstruct.len buf = 0 then Lwt.return_unit else
       match !next with
@@ -72,34 +78,45 @@ let make_channel role test_sequence =
         let available = min (Cstruct.len buf) (String.length x) in
         let written = String.sub (Cstruct.to_string buf) 0 available in
         let expected = String.sub x 0 available in
-        Alcotest.(check string) "Wrote expected data" expected written;
+        Alcotest.(check (of_pp (Fmt.of_to_string String.escaped))) "Wrote expected data" expected written;
+        Lwt_io.printlf "Wrote %s" (written |> String.escaped) >>= fun () ->
+        Lwt_io.flush_all () >>= fun () -> (* Ensure all debug messages get logged *)
         next := if available = String.length x then rest else (source, (String.sub x available (String.length x - available))) :: rest;
         let buf = Cstruct.shift buf available in
         if Cstruct.len buf = 0
         then Lwt.return ()
         else write buf
-      | [] -> Lwt.fail_with "Tried to write but the stream was empty" in
+      | [] ->
+        Lwt.fail_with
+          (Printf.sprintf
+             "Tried to write %s but the stream was empty"
+             (buf |> Cstruct.to_string |> String.escaped))
+  in
   let close () = Lwt.return () in
-  let assert_processed_complete_sequence () = Alcotest.(check (list transmission)) "processed complete sequence" [] !next in
+  let assert_processed_complete_sequence () = Alcotest.(check (list transmission)) "did not process complete sequence" !next [] in
   (assert_processed_complete_sequence, (read, write, close))
 
 (** Passes a channel for use by the NBD client to the given function, verifying
     that all communcation matches the given test sequence and that the complete
-    sequence has been processed after the function returns. *)
+    sequence has been processed after the function returns.
+    Returns a function that can be passed to create a Alcotest_lwt.test_case *)
 let with_client_channel s f =
-  fun () ->
+  fun _switch () ->
     let (assert_processed_complete_sequence, (read, write, close)) = make_channel `Client s in
-    f Channel.{read; write; close; is_tls=false};
-    assert_processed_complete_sequence ()
+    f Nbd.Channel.{read; write; close; is_tls=false} >>= fun () ->
+    assert_processed_complete_sequence ();
+    Lwt.return_unit
 
 (** Passes a channel for use by the NBD server to the given function, verifying
     that all communcation matches the given test sequence and that the complete
-    sequence has been processed after the function returns. *)
+    sequence has been processed after the function returns.
+    Returns a function that can be passed to create a Alcotest_lwt.test_case *)
 let with_server_channel s f =
-  fun () ->
+  fun _switch () ->
     let (assert_processed_complete_sequence, (read, write, close)) = make_channel `Server s in
-    f Channel.{read_clear=read; write_clear=write; close_clear=close; make_tls_channel=None};
-    assert_processed_complete_sequence ()
+    f Nbd.Channel.{read_clear=read; write_clear=write; close_clear=close; make_tls_channel=None} >>= fun () ->
+    assert_processed_complete_sequence ();
+    Lwt.return_unit
 
 module V2_negotiation = struct
 
@@ -115,95 +132,204 @@ module V2_negotiation = struct
     `Client, "export1";
   ]
 
+  (* The server only sends this extra data after Nbd.Server.connect when we call Nbd.Server.serve *)
   let v2_negotiation = v2_negotiation_start @ [
     `Server, "\000\000\000\000\001\000\000\000"; (* size *)
     `Server, "\000\001"; (* transmission flags: NBD_FLAG_HAS_FLAGS (bit 0) *)
     `Server, (String.make 124 '\000');
   ]
 
-  let client_negotiation =
-    "Perform a negotiation using the second version of the protocol from the
-     client's side.",
-    `Quick,
-    with_client_channel v2_negotiation (fun channel ->
-        let t =
-          Client.negotiate channel "export1"
-          >>= fun (t, size, flags) ->
-          Lwt.return ()
-        in
-        Lwt_main.run t
-      )
+  let test_client =
+    Alcotest_lwt.test_case
+      "Perform a negotiation using the second version of the protocol from the
+     client's side."
+      `Quick
+      (with_client_channel v2_negotiation (fun channel ->
+           Nbd.Client.negotiate channel "export1"
+           >>= fun (t, size, flags) ->
+           Lwt.return ()
+         ))
 
-  let server_negotiation =
-    "Perform a negotiation using the second version of the protocol from the
-     server's side.",
-    `Quick,
-    with_server_channel v2_negotiation_start (fun channel ->
-        let t =
-          Server.connect channel ()
-          >>= fun (export_name, svr) ->
-          Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name;
-          Lwt.return_unit
-        in
-        Lwt_main.run t
-      )
+  let test_server =
+    Alcotest_lwt.test_case
+      "Perform a negotiation using the second version of the protocol from the
+     server's side."
+      `Quick
+      (with_server_channel v2_negotiation_start (fun channel ->
+           Nbd.Server.connect channel ()
+           >|= fun (export_name, svr) ->
+           Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name
+         ))
+end
+
+module V2_abort = struct
+  let sequence = [
+    `Server, "NBDMAGIC";
+    `Server, "IHAVEOPT";
+    `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+    `Client, "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\002";
+    `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
+    `Server, "\000\000\000\000";
+  ]
+
+  let test_server =
+    Alcotest_lwt.test_case
+      "Client connects then aborts"
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Lwt.catch
+             (fun () ->
+                Nbd.Server.connect channel () >>= fun _ ->
+                Alcotest.fail "Server should not enter transmission mode"
+             )
+             (function
+               | Nbd.Server.Client_requested_abort -> Lwt.return_unit
+               | e -> Lwt.fail e)
+         ))
+end
+
+module V2_abort_without_ack = struct
+  (** The NBD protocol says: "the server SHOULD gracefully handle the client
+   * sending an NBD_OPT_ABORT and closing the connection without waiting for a
+   * reply." *)
+
+  let sequence = [
+    `Server, "NBDMAGIC";
+    `Server, "IHAVEOPT";
+    `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+    `Client, "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+  ]
+
+  let test_server =
+    Alcotest_lwt.test_case
+      "Client connects then aborts without reading ack"
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Lwt.catch
+             (fun () ->
+                Nbd.Server.connect channel () >>= fun _ ->
+                Alcotest.fail "Server should not enter transmission mode"
+             )
+             (function
+               | Nbd.Server.Client_requested_abort -> Lwt.return_unit
+               | e -> Lwt.fail e)
+         ))
 end
 
 module V2_list_export_disabled = struct
 
-  let v2_list_export_disabled = [
+  let sequence = [
     `Server, "NBDMAGIC"; (* read *)
     `Server, "IHAVEOPT";
     `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
     `Client, "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
+
     `Client, "IHAVEOPT";
     `Client, "\000\000\000\003"; (* NBD_OPT_LIST *)
     `Client, "\000\000\000\000";
+
     `Server, option_reply_magic_number;
     `Server, "\000\000\000\003";
-    `Server, "\128\000\000\002";
+    `Server, "\128\000\000\002"; (* NBD_REP_ERR_POLICY *)
+    `Server, "\000\000\000\000";
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\002";
+    `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
     `Server, "\000\000\000\000";
   ]
 
-  let client_list_disabled =
-    "Check that if we request a list of exports and are denied, the error is
-     reported properly.",
-    `Quick,
-    with_client_channel v2_list_export_disabled (fun channel ->
-        let t =
-          Client.list channel
-          >>= function
-          | Error `Policy ->
-            Lwt.return ()
-          | _ -> failwith "Expected to receive a Policy error" in
-        Lwt_main.run t
-      )
+  let test_client =
+    Alcotest_lwt.test_case
+      "Check that if we request a list of exports and are denied, the error is
+     reported properly."
+      `Quick
+      (with_client_channel sequence (fun channel ->
+           Nbd.Client.list channel
+           >>= function
+           | Error `Policy ->
+             Lwt.return ()
+           | _ -> failwith "Expected to receive a Policy error"
+         ))
 
-  let server_list_disabled =
-    "Check that the server denies listing the exports, and the error is
-     reported properly.",
-    `Quick,
-    with_server_channel v2_list_export_disabled (fun channel ->
-        let t () =
-          Server.connect channel ()
-          >>= fun (_export_name, _svr) ->
-          Lwt.return_unit
-        in
-        (* TODO: The Client.list function currently does not send
-           NBD_OPT_ABORT when it should, but incorrectly disconnects, so we
-           expect this error from the server side. *)
-        try
-          Lwt_main.run (t ())
-        with Failed_to_read_empty_stream -> ()
-      )
+  let test_server =
+    Alcotest_lwt.test_case
+      "Check that the server denies listing the exports, and the error is
+     reported properly."
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Lwt.catch
+             (fun () ->
+                Nbd.Server.connect channel () >>= fun _ ->
+                Alcotest.fail "Server should not enter transmission mode"
+             )
+             (function
+               | Nbd.Server.Client_requested_abort -> Lwt.return_unit
+               | e -> Lwt.fail e)
+         ))
 end
 
-module V2_list_export_success = struct
-  let v2_list_export_success = [
+module V2_no_ack_after_abort = struct
+  (** After a NBD_OPT_LIST, the client sends an abort, but the server
+   * disconnects without sending an ack. The NBD protocol says: "the client
+   * SHOULD gracefully handle the server closing the connection after receiving
+   * an NBD_OPT_ABORT without it sending a reply" *)
+
+  let sequence = [
     `Server, "NBDMAGIC"; (* read *)
     `Server, "IHAVEOPT";
     `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
     `Client, "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\003"; (* NBD_OPT_LIST *)
+    `Client, "\000\000\000\000";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\003";
+    `Server, "\128\000\000\002"; (* NBD_REP_ERR_POLICY *)
+    `Server, "\000\000\000\000";
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+  ]
+
+  let test_client =
+    Alcotest_lwt.test_case
+      "Server denies listing exports, and disconnects after abort without sending ack"
+      `Quick
+      (with_client_channel sequence (fun channel ->
+           Nbd.Client.list channel
+           >>= function
+           | Error `Policy ->
+             Lwt.return ()
+           | _ -> failwith "Expected to receive a Policy error"
+         ))
+end
+
+module V2_list_export_success = struct
+  let sequence = [
+    `Server, "NBDMAGIC"; (* read *)
+    `Server, "IHAVEOPT";
+    `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
+    `Client, "\000\000\000\001"; (* client flags: NBD_FLAG_C_FIXED_NEWSTYLE *)
+
     `Client, "IHAVEOPT";
     `Client, "\000\000\000\003"; (* NBD_OPT_LIST *)
     `Client, "\000\000\000\000";
@@ -217,27 +343,56 @@ module V2_list_export_success = struct
 
     `Server, option_reply_magic_number;
     `Server, "\000\000\000\003";
+    `Server, "\000\000\000\002"; (* NBD_REP_SERVER *)
+    `Server, "\000\000\000\011";
+    `Server, "\000\000\000\007";
+    `Server, "export2";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\003";
+    `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
+    `Server, "\000\000\000\000";
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\002";
     `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
     `Server, "\000\000\000\000";
   ]
 
-  let client_list_success =
-    "Check that if we request a list of exports, a list is returned and parsed
-     properly.",
-    `Quick,
-    with_client_channel v2_list_export_success (fun channel ->
-        let t =
-          Client.list channel
-          >>= function
-          | Ok [ "export1" ] ->
-            Lwt.return ()
-          | _ -> failwith "Expected to receive a list of exports" in
-        Lwt_main.run t
-      )
+  let test_client =
+    Alcotest_lwt.test_case
+      "Client requests a list of exports"
+      `Quick
+      (with_client_channel sequence (fun channel ->
+           Nbd.Client.list channel >|= fun res ->
+           Alcotest.(check (result (slist string String.compare) reject))
+             "Returned correct export names"
+             (Ok [ "export1"; "export2" ])
+             res
+         ))
+
+  let test_server =
+    Alcotest_lwt.test_case
+      "Client requests a list of exports"
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Lwt.catch
+             (fun () ->
+                Nbd.Server.connect ~offer:["export1";"export2"] channel () >>= fun _ ->
+                Alcotest.fail "Server should not enter transmission mode"
+             )
+             (function
+               | Nbd.Server.Client_requested_abort -> Lwt.return_unit
+               | e -> Lwt.fail e)
+         ))
 end
 
 module V2_list_export_extra_data = struct
-  let v2_list_export_extra_data = [
+  let sequence = [
     `Server, "NBDMAGIC"; (* read *)
     `Server, "IHAVEOPT";
     `Server, "\000\001"; (* handshake flags: NBD_FLAG_FIXED_NEWSTYLE *)
@@ -258,20 +413,28 @@ module V2_list_export_extra_data = struct
     `Server, "\000\000\000\003";
     `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
     `Server, "\000\000\000\000";
+
+    `Client, "IHAVEOPT";
+    `Client, "\000\000\000\002"; (* NBD_OPT_ABORT *)
+    `Client, "\000\000\000\000";
+
+    `Server, option_reply_magic_number;
+    `Server, "\000\000\000\002";
+    `Server, "\000\000\000\001"; (* NBD_REP_ACK *)
+    `Server, "\000\000\000\000";
   ]
 
-  let client_list_extra_data =
-    "List exports with extra data after export name",
-    `Quick,
-    with_client_channel v2_list_export_extra_data (fun channel ->
-        let t =
-          Client.list channel
-          >>= function
-          | Ok [ "export2" ] ->
-            Lwt.return ()
-          | _ -> failwith "Expected to receive a list of exports" in
-        Lwt_main.run t
-      )
+  let test_client =
+    Alcotest_lwt.test_case
+      "List exports with extra data after export name"
+      `Quick
+      (with_client_channel sequence (fun channel ->
+           Nbd.Client.list channel
+           >>= function
+           | Ok [ "export2" ] ->
+             Lwt.return ()
+           | _ -> failwith "Expected to receive a list of exports"
+         ))
 end
 
 module V2_read_only_test = struct
@@ -339,17 +502,15 @@ module V2_read_only_test = struct
   ]
 
   let server_test =
-    "Serve a read-only export and test that reads and writes are handled correctly.",
-    `Quick,
-    with_server_channel sequence (fun channel ->
-        let t =
-          Server.connect channel ()
-          >>= fun (export_name, svr) ->
-          Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name;
-          Server.serve svr ~read_only:true (module Cstruct_block.Block) test_block
-        in
-        Lwt_main.run t
-      )
+    Alcotest_lwt.test_case
+      "Serve a read-only export and test that reads and writes are handled correctly."
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Nbd.Server.connect channel ()
+           >>= fun (export_name, svr) ->
+           Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name;
+           Nbd.Server.serve svr ~read_only:true (module Cstruct_block.Block) test_block
+         ))
 
 end
 
@@ -395,31 +556,34 @@ module V2_write_test = struct
   ]
 
   let server_test =
-    "Serve a read-write export and test that writes are handled correctly.",
-    `Quick,
-    with_server_channel sequence (fun channel ->
-        let t =
-          Server.connect channel ()
-          >>= fun (export_name, svr) ->
-          Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name;
-          Server.serve svr ~read_only:false (module Cstruct_block.Block) test_block
-        in
-        Lwt_main.run t;
-        Alcotest.(check string) "Data written by server"
-          "as12"
-          (Cstruct.to_string test_block)
-      )
+    Alcotest_lwt.test_case
+      "Serve a read-write export and test that writes are handled correctly."
+      `Quick
+      (with_server_channel sequence (fun channel ->
+           Nbd.Server.connect channel ()
+           >>= fun (export_name, svr) ->
+           Alcotest.(check string) "The server did not receive the correct export name" "export1" export_name;
+           Nbd.Server.serve svr ~read_only:false (module Cstruct_block.Block) test_block
+           >|= fun () ->
+           Alcotest.(check string) "Data written by server"
+             "as12"
+             (Cstruct.to_string test_block)
+         ))
 
 end
 
 let tests =
-  "Nbd client tests",
-  [ V2_negotiation.client_negotiation
-  ; V2_negotiation.server_negotiation
-  ; V2_list_export_disabled.client_list_disabled
-  ; V2_list_export_disabled.server_list_disabled
-  ; V2_list_export_success.client_list_success
-  ; V2_list_export_extra_data.client_list_extra_data
+  "Nbd protocol tests",
+  [ V2_negotiation.test_client
+  ; V2_negotiation.test_server
+  ; V2_abort.test_server
+  ; V2_abort_without_ack.test_server
+  ; V2_list_export_disabled.test_client
+  ; V2_list_export_disabled.test_server
+  ; V2_no_ack_after_abort.test_client
+  ; V2_list_export_success.test_client
+  ; V2_list_export_success.test_server
+  ; V2_list_export_extra_data.test_client
   ; V2_read_only_test.server_test
   ; V2_write_test.server_test
   ]

--- a/nbd.opam
+++ b/nbd.opam
@@ -13,6 +13,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {test}
+  "alcotest-lwt" {test}
   "cstruct" {>= "3.1.0"}
   "io-page"
   "mirage-block-lwt"


### PR DESCRIPTION
Various fixes to make the client and server conform more to the NBD
protocol:
* Ensure Client.list terminates the option haggling by sending an abort.
  This change should not cause problems, as currently we don't seem to
  use Client.list anywhere.
* Fix the server's response to NBD_OPT_LIST - previously it did not send
  the lenghts to the client correctly, and therefore qemu-img and
  nbd-client could not list the exports.
* Check that the lengths the export names in the optional ~offer param
  passed to Server.connect are below the maximum limit allowed by the NBD
  protocol.
* Ensure the server responds to an abort with an ack. This change
  shouldn't cause issues either, because we gracefully handle the case
  without failing where the client disconnects without waiting for the
  ack.
* Clean up existing protocol unit tests, add more logging, and more
  tests for these corner cases.
* Add a new client<->server interaction test to check that NBD_OPT_LIST
  is implemented properly in both.

Fixes #130 #128 #102 

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>