### PR TITLE
Add exportname option to CLI and interop tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,26 +11,31 @@ env:
   - secure: iS8MtXltyXj/T1EgpZaMillH/SuMAinX7ma5ER1Zt54F9CS3/tH+pG9Yx8uM8sUOZU90xvmN0AZ4HI4sPzquj8UUS+a0Xoj4kj43eGG90bi3nqtdNtopQOZpLFhvm7+tMzRztHLocvlPWLu1l8xHeGycm+J7X1sx+CW+p4uotPE=
   - PINS="nbd:. nbd-lwt-unix:. nbd-tool:."
   - SCRIPT=.travis-docker.sh
+  # Pass through these extra env vars into the Docker container
+  # STRICT=true: Fail the nbd-tool interop tests if the requirements are missing
+  - EXTRA_ENV="STRICT=true"
   matrix:
-  # We need to pass some Travis environment variables to the container to
-  # enable uploading to coveralls and detection of Travis CI.
-  # Also, set TESTS to false to avoid running them twice.
-  # We also have to install the test dependencies because they are not there
-  # when POST_INSTALL_HOOK is run, even if TESTS is set to true.
   - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.06 \
-    TESTS=false \
-    POST_INSTALL_HOOK="opam install alcotest alcotest-lwt io-page-unix; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
   - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.07
   # Upload docs for both nbd and nbd-lwt-unix
   - PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.06 SCRIPT=.travis-docker-docgen.sh
   - PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.07
-  - PACKAGE=nbd-tool  DISTRO="debian-unstable" OCAML_VERSION=4.06
-  - PACKAGE=nbd-tool  DISTRO="debian-unstable" OCAML_VERSION=4.07
+  # We set TESTS to false to avoid running them twice.
+  # We install the packages used for interop tests with nbd-tool in
+  # PRE_INSTALL_HOOK.
+  # We also have to install the opam test dependencies because they are not there
+  # when POST_INSTALL_HOOK is run, even if TESTS is set to true.
+  # And we hvae to pass some Travis environment variables to the container to
+  # enable uploading to coveralls and detection of Travis CI.
+  - PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client" OCAML_VERSION=4.06 \
+    TESTS=false \
+    POST_INSTALL_HOOK="opam install alcotest alcotest-lwt io-page-unix; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
+  - PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client" OCAML_VERSION=4.07
 matrix:
   fast_finish: true
   allow_failures:
     - env: PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.07
     - env: PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.07
-    - env: PACKAGE=nbd-tool  DISTRO="debian-unstable" OCAML_VERSION=4.07
+    - env: PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client" OCAML_VERSION=4.07
 branches:
   only: master

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 test:
 	dune runtest
 
-# requires sudo access, nbd-client, and hdparm
+# requires qemu-img
 benchmark: build
 	./benchmark.sh
 

--- a/cli_test/dune
+++ b/cli_test/dune
@@ -1,0 +1,20 @@
+(executable
+ (name suite)
+ (libraries
+  alcotest
+  alcotest-lwt
+  cmdliner
+ )
+)
+
+(alias
+ (name runtest)
+ (package nbd-tool)
+ (deps
+  (:suite suite.exe)
+  (:cli ../cli/main.exe)
+  ./test-qemu.sh
+  ./test-nbd-client.sh
+ )
+ (action (run %{suite} --cli %{cli}))
+)

--- a/cli_test/suite.ml
+++ b/cli_test/suite.ml
@@ -1,0 +1,42 @@
+
+let with_command ~command ~strict test =
+  match Sys.command ("command -v " ^ command) with
+  | 0 -> test ()
+  | _ ->
+    if strict then failwith ("Command " ^ command ^ " not present")
+    else Printf.printf "!!! Skipping test because command %s is not available" command
+
+let script name ~requires (cli, strict) =
+  with_command
+    ~command:requires
+    ~strict
+    (fun () ->
+       Alcotest.(check int)
+         name
+         0
+         (Sys.command (name ^ " " ^ cli))
+    )
+
+let cli =
+  let doc = "Path to nbd CLI should be first command-line argument" in
+  Cmdliner.Arg.(required & opt ~vopt:None (some string) None & info ["cli"] ~docv:"CLI" ~doc)
+
+let strict =
+  let doc = {|If present, the test will fail when the required program is not
+              installed. Otherwise the test will simply be skipped.|}
+  in
+  Cmdliner.Arg.(value & flag & info ["strict"] ~env:(env_var "STRICT") ~doc)
+
+let opts = Cmdliner.Term.(const (fun cli strict -> (cli, strict)) $ cli $ strict)
+
+let () =
+  Alcotest.run_with_args
+    "Nbd CLI interoperability tests"
+    opts
+    [ ("compatibility with qemu-img",
+       ["data copying", `Slow, script "./test-qemu.sh" ~requires:"qemu-img"]
+      )
+    ; ("compatibility with nbd-client",
+       ["listing exports", `Slow, script "./test-nbd-client.sh" ~requires:"nbd-client"]
+      )
+    ]

--- a/cli_test/test-nbd-client.sh
+++ b/cli_test/test-nbd-client.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eux
+
+CLI=$1
+
+SCRATCH=$(mktemp -d)
+EXPORT=$SCRATCH/test
+
+# Create a test file
+dd if=/dev/urandom of="$EXPORT" bs=1M count=40
+
+# Serve it
+$CLI serve --exportname test --no-tls "$EXPORT" &
+SERVER=$!
+# Wait for the server to start the main loop
+sleep 0.1
+
+stop_server() {
+  kill -9 $SERVER
+}
+trap stop_server EXIT
+
+# Try listing the exports
+# This will fail if the server does not implement NBD_OPT_LIST correctly
+nbd-client -l 0.0.0.0

--- a/cli_test/test-qemu.sh
+++ b/cli_test/test-qemu.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eux
+
+CLI=$1
+
+SCRATCH=$(mktemp -d)
+EXPORT=$SCRATCH/test
+OUTPUT=$SCRATCH/out
+
+# Create a test file
+dd if=/dev/urandom of="$EXPORT" bs=1M count=40
+
+# Serve it
+$CLI serve --exportname test --no-tls "$EXPORT" &
+SERVER=$!
+# Wait for the server to start the main loop
+sleep 0.1
+
+stop_server() {
+  kill -9 $SERVER
+}
+trap stop_server EXIT
+
+# Download it as raw from the server
+qemu-img convert 'nbd:0.0.0.0:10809:exportname=test' -O raw "$OUTPUT"
+
+# Check that the two files are the same
+cmp --silent "$EXPORT" "$OUTPUT"

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,4 +1,4 @@
-(executable
+(test
  (name suite)
  (libraries
   alcotest
@@ -8,8 +8,3 @@
   lwt_log
   nbd)
 )
-
-(alias
- (name   runtest)
- (deps   (:suite suite.exe))
- (action (run %{suite})))

--- a/nbd-tool.opam
+++ b/nbd-tool.opam
@@ -6,8 +6,11 @@ homepage: "https://github.com/xapi-project/nbd"
 dev-repo: "https://github.com/xapi-project/nbd.git"
 bug-reports: "https://github.com/xapi-project/nbd/issues"
 build: ["dune" "build" "-p" name "-j" jobs]
+build-test: ["dune" "runtest" "-p" name]
 depends: [
   "dune" {build}
+  "alcotest" {test}
+  "alcotest-lwt" {test}
   "cmdliner"
   "lwt" {>= "2.7.0"}
   "lwt_log"

--- a/nbd.opam
+++ b/nbd.opam
@@ -14,6 +14,7 @@ depends: [
   "dune" {build}
   "alcotest" {test}
   "alcotest-lwt" {test}
+  "io-page-unix" {test}
   "cstruct" {>= "3.1.0"}
   "io-page"
   "mirage-block-lwt"


### PR DESCRIPTION
Add an option to specify an export name when serving a file. If
specified, only this export name will be accepted, and the client will
be allowed to list the exports.

If unspecified, the behavior is the same as before: listing the exports
is not allowed, and any export name is accepted.

I've added compatibility tests with qemu-img and nbd-client. By default,
these test are skipped if the required programs aren't installed. If the
strict option is enabled, the tests will fail instead of being skipped.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>