### PR TITLE
CA-307773: initialize EC curves

### DIFF
--- a/lwt/nbd_lwt_unix.ml
+++ b/lwt/nbd_lwt_unix.ml
@@ -105,13 +105,17 @@ let connect hostname port =
   >>= fun () ->
   (generic_channel_of_fd socket None)
 
-let init_tls_get_ctx ~certfile ~ciphersuites =
+let init_tls_get_ctx ?curve ~certfile ~ciphersuites =
   Ssl_threads.init ();
   Ssl.init ();
   let mk_ctx role_ctx = Ssl.create_context Ssl.TLSv1_2 role_ctx in
   let ctx = mk_ctx Ssl.Server_context in
   Ssl.use_certificate ctx certfile certfile; (* Second one is being used as privkey filename *)
   Ssl.set_cipher_list ctx ciphersuites;
+  begin match curve with
+  | None -> ()
+  | Some curve -> Ssl.init_ec_from_named_curve ctx curve;
+  end;
   ctx
 
 let with_block filename f =

--- a/lwt/nbd_lwt_unix.mli
+++ b/lwt/nbd_lwt_unix.mli
@@ -28,7 +28,7 @@ val cleartext_channel_of_fd: Lwt_unix.file_descr -> tls_role option -> Channel.c
 (** [cleartext_channel_of_fd fd role] returns a channel from an existing file descriptor.
     The channel will have a [make_tls_channel] value that corresponds to [role]. *)
 
-val init_tls_get_ctx: certfile:string -> ciphersuites:string -> Ssl.context
+val init_tls_get_ctx: ?curve:string -> certfile:string -> ciphersuites:string -> Ssl.context
 (** Initialise the Ssl (TLS) library and then create and return a new context. *)
 
 val with_block: string -> (Block.t -> 'a Block.io) -> 'a Block.io


### PR DESCRIPTION
ECDHE ciphersuites are not working at all currently.

After we do this we'll also need to update xapi-nbd to pass `~curve:"secp384r1"`