### PR TITLE
CA-307773: add unit argument

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -167,7 +167,7 @@ module Impl = struct
       let certfile = require_str "certfile" certfile in
       let ciphersuites = require_str "ciphersuites" ciphersuites in
       Some (Nbd_lwt_unix.TlsServer
-              (Nbd_lwt_unix.init_tls_get_ctx ~curve ~certfile ~ciphersuites)
+              (Nbd_lwt_unix.init_tls_get_ctx ~curve ~certfile ~ciphersuites ())
            )
     )
 

--- a/lwt/nbd_lwt_unix.ml
+++ b/lwt/nbd_lwt_unix.ml
@@ -105,7 +105,7 @@ let connect hostname port =
   >>= fun () ->
   (generic_channel_of_fd socket None)
 
-let init_tls_get_ctx ?curve ~certfile ~ciphersuites =
+let init_tls_get_ctx ?curve ~certfile ~ciphersuites () =
   Ssl_threads.init ();
   Ssl.init ();
   let mk_ctx role_ctx = Ssl.create_context Ssl.TLSv1_2 role_ctx in

--- a/lwt/nbd_lwt_unix.mli
+++ b/lwt/nbd_lwt_unix.mli
@@ -28,7 +28,7 @@ val cleartext_channel_of_fd: Lwt_unix.file_descr -> tls_role option -> Channel.c
 (** [cleartext_channel_of_fd fd role] returns a channel from an existing file descriptor.
     The channel will have a [make_tls_channel] value that corresponds to [role]. *)
 
-val init_tls_get_ctx: ?curve:string -> certfile:string -> ciphersuites:string -> Ssl.context
+val init_tls_get_ctx: ?curve:string -> certfile:string -> ciphersuites:string -> unit -> Ssl.context
 (** Initialise the Ssl (TLS) library and then create and return a new context. *)
 
 val with_block: string -> (Block.t -> 'a Block.io) -> 'a Block.io


### PR DESCRIPTION
All arguments to init_tls_get_ctx are labeled so if we don't supply `curve` the build fails.
Add a unit argument to make it possible to omit the curve argument if we want to in the future.

