### PR TITLE
maintenance: upgrade alcotest to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,18 @@
 language: c
-sudo: false
-services:
-  - docker
+dist: xenial
+service: docker
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install qemu-utils nbd-client netcat-openbsd
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-  - wget https://raw.githubusercontent.com/xapi-project/xapi-travis-scripts/master/coverage.sh
-script: bash ./$SCRIPT
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
+script: bash -ex .travis-docker.sh
 env:
   global:
-  - secure: iS8MtXltyXj/T1EgpZaMillH/SuMAinX7ma5ER1Zt54F9CS3/tH+pG9Yx8uM8sUOZU90xvmN0AZ4HI4sPzquj8UUS+a0Xoj4kj43eGG90bi3nqtdNtopQOZpLFhvm7+tMzRztHLocvlPWLu1l8xHeGycm+J7X1sx+CW+p4uotPE=
-  - PINS="nbd.master:. nbd-lwt-unix.master:. nbd-tool.master:."
-  - SCRIPT=.travis-docker.sh
-  # Pass through these extra env vars into the Docker container
-  # STRICT=true: Fail the nbd-tool interop tests if the requirements are missing
-  - EXTRA_ENV="STRICT=true"
-  matrix:
-  - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.06 \
-  - PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.07
-  # Upload docs for both nbd and nbd-lwt-unix
-  - PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.06 SCRIPT=.travis-docker-docgen.sh
-  - PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.07
-  # We set TESTS to false to avoid running them twice.
-  # We install the packages used for interop tests with nbd-tool in
-  # PRE_INSTALL_HOOK.
-  # We also have to install the opam test dependencies because they are not there
-  # when POST_INSTALL_HOOK is run, even if TESTS is set to true.
-  # And we hvae to pass some Travis environment variables to the container to
-  # enable uploading to coveralls and detection of Travis CI.
-  - PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client netcat-openbsd" OCAML_VERSION=4.06 \
-    TESTS=false \
-    POST_INSTALL_HOOK="opam install alcotest alcotest-lwt io-page-unix; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
-  - PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client netcat-openbsd" OCAML_VERSION=4.07
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: PACKAGE=nbd  DISTRO="debian-unstable" OCAML_VERSION=4.07
-    - env: PACKAGE=nbd-lwt-unix  DISTRO="debian-unstable" OCAML_VERSION=4.07
-    - env: PACKAGE=nbd-tool DISTRO="debian-unstable" PRE_INSTALL_HOOK="sudo apt-get install -y qemu-utils nbd-client" OCAML_VERSION=4.07
-branches:
-  only: master
+    - PINS="nbd.master:. nbd-lwt-unix.master:. nbd-tool.master:."
+  jobs:
+    - PACKAGE="nbd"
+    - PACKAGE="nbd-lwt-unix"
+    - PACKAGE="nbd-tool"

--- a/lib_test/suite.ml
+++ b/lib_test/suite.ml
@@ -1,8 +1,15 @@
 
 let () =
+  Lwt_main.run @@
+    Alcotest_lwt.run
+      "Lwt Nbd library test suite"
+      (* I found that running the protocol tests before the
+         client server tests causes the test suite to hang
+       *)
+      [ Client_server_test.tests
+      ; Protocol_test.tests
+      ];
   Alcotest.run
-    "Nbd library test suite"
+    "Sync Nbd library test suite"
     [ Mux_test.tests
-    ; Protocol_test.tests
-    ; Client_server_test.tests
     ]


### PR DESCRIPTION
Note that running the tests in a certain order
causes them to hang. I did not find the cause
of this.