### PR TITLE
require mirage-block 3.0.0, drop io-page-unix

### DIFF
--- a/.github/workflows/ocaml-ci.yml
+++ b/.github/workflows/ocaml-ci.yml
@@ -6,38 +6,30 @@ on:
 
 jobs:
   ocaml-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-compiler:
+          - 4.08.1
+          - 4.14.0
+
     name: Ocaml tests
     runs-on: ubuntu-20.04
-    env:
-      package: "nbd nbd-tool nbd-unix"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Pull configuration from xs-opam
-        run: |
-          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
-
-      - name: Load environment file
-        id: dotenv
-        uses: falti/dotenv-action@v0.2.4
-
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: avsm/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Install dependencies
-        run: |
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam install ${{ env.package }} --deps-only --with-test -v
+        run: opam install . --deps-only --with-test -v
 
       - name: Build
-        run: |
-          opam exec -- make build
+        run: opam exec -- make build
 
       - name: Run tests
         run: opam exec -- dune runtest --instrument-with bisect_ppx --force

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+# 6.0.1 (2022-09-16):
+* Require mirage-block 3.0.0, drop io-page-unix.
+
 # 6.0.0 (2022-08-19):
 * Use Stdlib's Result type
 * BREAKING: Avoid unerasable optional arguments in init_tls_get_ctx

--- a/cli/dune
+++ b/cli/dune
@@ -3,4 +3,15 @@
  (name main)
  (public_name nbd-tool)
  (package nbd-tool)
- (libraries cmdliner lwt lwt.unix mirage-block-unix nbd-unix ssl uri))
+ (libraries
+   cmdliner
+   fmt
+   lwt
+   lwt.unix
+   lwt_log
+   mirage-block
+   mirage-block-unix
+   nbd
+   nbd-unix
+   ssl
+   uri))

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -72,8 +72,6 @@ module Device = struct
         Block.read t off bufs >>= function
         | Result.Error `Disconnected ->
             Lwt.return_error `Disconnected
-        | Result.Error `Unimplemented ->
-            Lwt.return_error `Unimplemented
         | Result.Error _ ->
             Lwt.return_error `Disconnected
         | Result.Ok x ->
@@ -88,8 +86,6 @@ module Device = struct
         Block.write t off bufs >>= function
         | Result.Error `Disconnected ->
             Lwt.return_error `Disconnected
-        | Result.Error `Unimplemented ->
-            Lwt.return_error `Unimplemented
         | Result.Error `Is_read_only ->
             Lwt.return_error `Is_read_only
         | Result.Error _ ->

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,18 @@
  (public_name nbd)
  (flags
   (:standard -w -34-32))
- (libraries cstruct io-page lwt lwt_log mirage-block-unix rresult sexplib)
+ (libraries
+   cstruct
+   fmt
+   io-page
+   lwt
+   lwt_log
+   lwt_log.core
+   mirage-block
+   rresult
+   sexplib
+   sexplib0
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps ppx_cstruct ppx_sexp_conv -no-check)))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,3 +1,4 @@
 (tests
  (names suite mux_test)
- (libraries alcotest alcotest-lwt io-page-unix lwt.unix lwt_log nbd))
+ (package nbd)
+ (libraries alcotest alcotest-lwt io-page lwt.unix lwt_log nbd))

--- a/nbd-unix.opam
+++ b/nbd-unix.opam
@@ -12,11 +12,11 @@ doc: "https://xapi-project.github.io/nbd/nbd-unix/index.html"
 bug-reports: "https://github.com/xapi-project/nbd/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "bigarray-compat"
   "bisect_ppx" {dev & >= "2.5.0"}
   "dune" {>= "2.7.0"}
   "cstruct-lwt"
-  "io-page"
-  "io-page-unix"
+  "io-page" {>= "2.4.0"}
   "lwt" {>= "2.7.0"}
   "lwt_ssl"
   "mirage-block" {>= "2.0.0"}

--- a/nbd.opam
+++ b/nbd.opam
@@ -19,9 +19,8 @@ depends: [
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
   "cstruct" {>= "6.0.0"}
-  "io-page"
-  "io-page-unix" {with-test}
-  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.4.0"}
+  "mirage-block" {>= "3.0.0"}
   "mirage-block-unix"
   "lwt" {>= "2.7.0"}
   "lwt_log"
@@ -32,6 +31,7 @@ depends: [
   "sexplib"
   "uri"
 ]
+conflicts: ["result" {< "1.5"}]
 tags: [ "org:mirage" "org:xapi-project" ]
 synopsis: "Network Block Device (NBD) protocol implementation"
 description: """

--- a/unix/dune
+++ b/unix/dune
@@ -1,6 +1,16 @@
 (library
  (name nbd_unix)
  (public_name nbd-unix)
- (libraries cstruct-lwt io-page io-page.unix lwt lwt.unix mirage-block
-   mirage-block-unix ssl lwt_ssl nbd)
+ (libraries
+   bigarray-compat
+   cstruct
+   cstruct-lwt
+   io-page
+   lwt
+   lwt.unix
+   mirage-block
+   mirage-block-unix
+   ssl
+   lwt_ssl
+   nbd)
  (instrumentation (backend bisect_ppx)))


### PR DESCRIPTION
Now the dune dependencies are more explicit

fixes #161 